### PR TITLE
Fonts cleanup

### DIFF
--- a/ts/docx/run/index.ts
+++ b/ts/docx/run/index.ts
@@ -1,13 +1,14 @@
-import {XmlComponent, Attributes} from "../xml-components";
+import { Break } from "./break";
+import { Caps, SmallCaps } from "./caps";
+import { Bold, Italics } from "./formatting";
+import { RunProperties } from "./properties";
 import { RunFonts } from "./run-fonts";
-import {RunProperties} from "./properties";
-import {Bold, Italics} from "./formatting";
-import {Tab} from "./tab";
-import {Break} from "./break";
-import {SmallCaps, Caps} from "./caps";
-import {Strike, DoubleStrike} from "./strike";
-import {SubScript, SuperScript} from "./script";
-import {Underline} from "./underline"
+import { SubScript, SuperScript } from "./script";
+import { DoubleStrike, Strike } from "./strike";
+import { Tab } from "./tab";
+import { Underline } from "./underline";
+
+import { Attributes, XmlComponent } from "../xml-components";
 
 export class Run extends XmlComponent {
     private properties: RunProperties;
@@ -18,62 +19,62 @@ export class Run extends XmlComponent {
         this.root.push(this.properties);
     }
 
-    bold(): Run {
+    public bold(): Run {
         this.properties.push(new Bold());
         return this;
     }
 
-    italic(): Run {
+    public italic(): Run {
         this.properties.push(new Italics());
         return this;
     }
 
-    underline(): Run {
+    public underline(): Run {
         this.properties.push(new Underline());
         return this;
     }
 
-    break(): Run {
+    public break(): Run {
         this.root.splice(1, 0, new Break());
         return this;
     }
 
-    tab(): Run {
+    public tab(): Run {
         this.root.splice(1, 0, new Tab());
         return this;
     }
 
-    smallCaps(): Run {
+    public smallCaps(): Run {
         this.properties.push(new SmallCaps());
         return this;
     }
 
-    allCaps(): Run {
+    public allCaps(): Run {
         this.properties.push(new Caps());
         return this;
     }
 
-    strike(): Run {
+    public strike(): Run {
         this.properties.push(new Strike());
         return this;
     }
 
-    doubleStrike(): Run {
+    public doubleStrike(): Run {
         this.properties.push(new DoubleStrike());
         return this;
     }
 
-    subScript(): Run {
+    public subScript(): Run {
         this.properties.push(new SubScript());
         return this;
     }
 
-    superScript(): Run {
+    public superScript(): Run {
         this.properties.push(new SuperScript());
         return this;
     }
 
-    font(fontName: string): Run {
+    public font(fontName: string): Run {
         this.properties.push(new RunFonts(fontName));
         return this;
     }

--- a/ts/docx/run/index.ts
+++ b/ts/docx/run/index.ts
@@ -1,4 +1,5 @@
 import {XmlComponent, Attributes} from "../xml-components";
+import { RunFonts } from "./run-fonts";
 import {RunProperties} from "./properties";
 import {Bold, Italics} from "./formatting";
 import {Tab} from "./tab";
@@ -10,7 +11,6 @@ import {Underline} from "./underline"
 
 export class Run extends XmlComponent {
     private properties: RunProperties;
-
 
     constructor() {
         super("w:r");
@@ -70,6 +70,11 @@ export class Run extends XmlComponent {
 
     superScript(): Run {
         this.properties.push(new SuperScript());
+        return this;
+    }
+
+    font(fontName: string): Run {
+        this.properties.push(new RunFonts(fontName));
         return this;
     }
 }

--- a/ts/docx/run/run-fonts.ts
+++ b/ts/docx/run/run-fonts.ts
@@ -1,9 +1,9 @@
-import {XmlAttributeComponent, XmlComponent} from "../docx/xml-components";
+import {XmlAttributeComponent, XmlComponent} from "../xml-components";
 
 interface IRunFontAttributesProperties {
     ascii: string;
     hAnsi: string;
-    hint: string;
+    hint?: string;
 }
 
 class RunFontAttributes extends XmlAttributeComponent {
@@ -19,7 +19,7 @@ class RunFontAttributes extends XmlAttributeComponent {
 
 export class RunFonts extends XmlComponent {
 
-    constructor(ascii: string, hint: string) {
+    constructor(ascii: string, hint?: string) {
         super("w:rFonts");
         this.root.push(new RunFontAttributes({
             ascii: ascii,

--- a/ts/numbering/index.ts
+++ b/ts/numbering/index.ts
@@ -1,11 +1,11 @@
 import * as _ from "lodash";
 import { DocumentAttributes } from "../docx/document/document-attributes";
+import { RunFonts } from "../docx/run/run-fonts";
 import { MultiPropertyXmlComponent } from "../docx/xml-components";
 import { AbstractNumbering } from "./abstract-numbering";
 import { Indent } from "./indent";
 import { Level } from "./level";
 import { Num } from "./num";
-import { RunFonts } from "./run-fonts";
 
 export class Numbering extends MultiPropertyXmlComponent {
     private nextId: number;

--- a/ts/tests/docx/run/fontTests.ts
+++ b/ts/tests/docx/run/fontTests.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+import { RunFonts } from "../../../docx/run/run-fonts";
+import { Formatter } from "../../../export/formatter";
+
+describe("RunFonts", () => {
+
+    describe("#constructor()", () => {
+        it("uses the font name for both ascii and hAnsi", () => {
+            const tree = new Formatter().format(new RunFonts("Times"));
+            expect(tree).to.deep.equal({
+                "w:rFonts": [{_attr: {"w:ascii": "Times", "w:hAnsi": "Times"}}],
+            });
+        });
+
+        it("uses hint if given", () => {
+            const tree = new Formatter().format(new RunFonts("Times", "default"));
+            expect(tree).to.deep.equal({
+                "w:rFonts": [{_attr: {"w:ascii": "Times", "w:hAnsi": "Times", "w:hint": "default"}}],
+            });
+        });
+    });
+});

--- a/ts/tests/docx/run/runTest.ts
+++ b/ts/tests/docx/run/runTest.ts
@@ -1,10 +1,10 @@
+import { assert } from "chai";
 import { Run } from "../../../docx/run";
 import { TextRun } from "../../../docx/run/text-run";
-import { assert } from "chai";
+import { Formatter } from "../../../export/formatter";
 
-function jsonify(obj: Object) {
-    let stringifiedJson = JSON.stringify(obj);
-    return JSON.parse(stringifiedJson);
+function jsonify(obj: object) {
+    return JSON.parse(JSON.stringify(obj));
 }
 
 describe("Run", () => {
@@ -17,7 +17,7 @@ describe("Run", () => {
     describe("#bold()", () => {
         it("it should add bold to the properties", () => {
             run.bold();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:b");
         });
     });
@@ -25,7 +25,7 @@ describe("Run", () => {
     describe("#italic()", () => {
         it("it should add italics to the properties", () => {
             run.italic();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:i");
         });
     });
@@ -33,7 +33,7 @@ describe("Run", () => {
     describe("#underline()", () => {
         it("it should add underline to the properties", () => {
             run.underline();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:u");
         });
     });
@@ -41,7 +41,7 @@ describe("Run", () => {
     describe("#smallCaps()", () => {
         it("it should add smallCaps to the properties", () => {
             run.smallCaps();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:smallCaps");
         });
     });
@@ -49,7 +49,7 @@ describe("Run", () => {
     describe("#caps()", () => {
         it("it should add caps to the properties", () => {
             run.allCaps();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:caps");
         });
     });
@@ -57,7 +57,7 @@ describe("Run", () => {
     describe("#strike()", () => {
         it("it should add strike to the properties", () => {
             run.strike();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:strike");
         });
     });
@@ -65,25 +65,23 @@ describe("Run", () => {
     describe("#doubleStrike()", () => {
         it("it should add caps to the properties", () => {
             run.doubleStrike();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[0].root[0].rootKey, "w:dstrike");
         });
     });
 
     describe("#break()", () => {
         it("it should add break to the run", () => {
-            let run = new Run();
             run.break();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[1].rootKey, "w:br");
         });
     });
 
     describe("#tab()", () => {
         it("it should add break to the run", () => {
-            let run = new Run();
             run.tab();
-            let newJson = jsonify(run);
+            const newJson = jsonify(run);
             assert.equal(newJson.root[1].rootKey, "w:tab");
         });
     });

--- a/ts/tests/docx/run/runTest.ts
+++ b/ts/tests/docx/run/runTest.ts
@@ -1,4 +1,4 @@
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import { Run } from "../../../docx/run";
 import { TextRun } from "../../../docx/run/text-run";
 import { Formatter } from "../../../export/formatter";
@@ -83,6 +83,22 @@ describe("Run", () => {
             run.tab();
             const newJson = jsonify(run);
             assert.equal(newJson.root[1].rootKey, "w:tab");
+        });
+    });
+
+    describe("#font()", () => {
+        it("should allow chaining calls", () => {
+            expect(run.font("Times")).to.equal(run);
+        });
+
+        it("should set the font as named", () => {
+            run.font("Times");
+            const tree = new Formatter().format(run);
+            expect(tree).to.deep.equal({
+                "w:r": [
+                    {"w:rPr": [{"w:rFonts": [{_attr: {"w:ascii": "Times", "w:hAnsi": "Times"}}]}]},
+                ],
+            });
         });
     });
 });


### PR DESCRIPTION
Here's a smaller one for you:

* Moved run-fonts out of numbering and into docx/run
* linter warnings, linter warnings...
* Added `#font()` method to `Run`

The only really new thing is that now you can do:

```js
const run = new docx.TextRun().font('Times');
```