### PR TITLE
Tables!

### DIFF
--- a/ts/docx/document/index.ts
+++ b/ts/docx/document/index.ts
@@ -45,4 +45,11 @@ export class Document extends XmlComponent {
     public addTable(table: Table): void {
         this.body.push(table);
     }
+
+    public createTable(rows: number, cols: number): Table {
+        const table = new Table(rows, cols);
+        this.addTable(table);
+        return table;
+    }
+
 }

--- a/ts/docx/document/index.ts
+++ b/ts/docx/document/index.ts
@@ -1,7 +1,9 @@
 import { Paragraph } from "../paragraph";
+import { Table } from "../table";
 import { XmlComponent } from "../xml-components";
 import { Body } from "./body";
 import { DocumentAttributes } from "./document-attributes";
+
 export class Document extends XmlComponent {
     private body: Body;
 
@@ -38,5 +40,9 @@ export class Document extends XmlComponent {
         const para = new Paragraph(text);
         this.addParagraph(para);
         return para;
+    }
+
+    public addTable(table: Table): void {
+        this.body.push(table);
     }
 }

--- a/ts/docx/index.ts
+++ b/ts/docx/index.ts
@@ -2,4 +2,4 @@ export { Document } from "./document";
 export { Paragraph } from "./paragraph";
 export { Run } from "./run";
 export { TextRun } from "./run/text-run";
-export { Table } from './table';
+export { Table } from "./table";

--- a/ts/docx/index.ts
+++ b/ts/docx/index.ts
@@ -2,3 +2,4 @@ export { Document } from "./document";
 export { Paragraph } from "./paragraph";
 export { Run } from "./run";
 export { TextRun } from "./run/text-run";
+export { Table } from './table';

--- a/ts/docx/table.ts
+++ b/ts/docx/table.ts
@@ -1,3 +1,0 @@
-export class Table {
-
-}

--- a/ts/docx/table/grid.ts
+++ b/ts/docx/table/grid.ts
@@ -1,17 +1,19 @@
-import {XmlComponent, Attributes} from "../xml-components";
+import { XmlAttributeComponent, XmlComponent } from "../xml-components";
 
 export class TableGrid extends XmlComponent {
-    private cols: Array<GridCol>;
-    constructor(cols: Array<GridCol>) {
-        super('w:tblGrid');
-        this.cols = cols;
-        cols.forEach(col => this.root.push(col));
+    constructor(cols: number[]) {
+        super("w:tblGrid");
+        cols.forEach((col) => this.root.push(new GridCol(col)));
     }
+}
+
+class GridColAttributes extends XmlAttributeComponent<{w: number}> {
+    protected xmlKeys = {w: "w:w"};
 }
 
 export class GridCol extends XmlComponent {
     constructor(width?: number) {
-        super('w:gridCol');
-        this.root.push(new Attributes({w: width.toString()}))
+        super("w:gridCol");
+        this.root.push(new GridColAttributes({w: width}));
     }
 }

--- a/ts/docx/table/grid.ts
+++ b/ts/docx/table/grid.ts
@@ -14,6 +14,8 @@ class GridColAttributes extends XmlAttributeComponent<{w: number}> {
 export class GridCol extends XmlComponent {
     constructor(width?: number) {
         super("w:gridCol");
-        this.root.push(new GridColAttributes({w: width}));
+        if (width !== undefined) {
+            this.root.push(new GridColAttributes({w: width}));
+        }
     }
 }

--- a/ts/docx/table/grid.ts
+++ b/ts/docx/table/grid.ts
@@ -1,0 +1,17 @@
+import {XmlComponent, Attributes} from "../xml-components";
+
+export class TableGrid extends XmlComponent {
+    private cols: Array<GridCol>;
+    constructor(cols: Array<GridCol>) {
+        super('w:tblGrid');
+        this.cols = cols;
+        cols.forEach(col => this.root.push(col));
+    }
+}
+
+export class GridCol extends XmlComponent {
+    constructor(width?: number) {
+        super('w:gridCol');
+        this.root.push(new Attributes({w: width.toString()}))
+    }
+}

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -55,6 +55,11 @@ export class Table extends XmlComponent {
         this.properties.setWidth(type, width);
         return this;
     }
+
+    public fixedWidthLayout(): Table {
+        this.properties.fixedWidthLayout();
+        return this;
+    }
 }
 
 class TableRow extends XmlComponent {

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -86,17 +86,28 @@ class TableRowProperties extends XmlComponent {
 }
 
 class TableCell extends XmlComponent {
-    public content: Paragraph;
     private properties: TableCellProperties;
 
     constructor() {
         super("w:tc");
         this.properties = new TableCellProperties();
         this.root.push(this.properties);
-        // Table cells can have any block-level content, but for now
-        // we only allow a single paragraph:
-        this.content = new Paragraph();
-        this.root.push(this.content);
+    }
+
+    public push(content: Paragraph | Table): TableCell {
+        this.root.push(content);
+        return this
+    }
+
+    public prepForXml(): object {
+        // Cells must end with a paragraph
+        const retval = super.prepForXml();
+        const content = retval["w:tc"];
+        if (!content[content.length - 1]["w:p"]) {
+            content.push(new Paragraph().prepForXml());
+        }
+        return retval
+    }
     }
 }
 

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -108,6 +108,11 @@ class TableCell extends XmlComponent {
         }
         return retval
     }
+
+    public createParagraph(text?: string): Paragraph {
+        const para = new Paragraph(text);
+        this.push(para);
+        return para;
     }
 }
 

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -94,7 +94,7 @@ class TableCell extends XmlComponent {
         this.root.push(this.properties);
     }
 
-    public push(content: Paragraph | Table): TableCell {
+    public addContent(content: Paragraph | Table): TableCell {
         this.root.push(content);
         return this;
     }
@@ -111,7 +111,7 @@ class TableCell extends XmlComponent {
 
     public createParagraph(text?: string): Paragraph {
         const para = new Paragraph(text);
-        this.push(para);
+        this.addContent(para);
         return para;
     }
 }

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -1,7 +1,7 @@
 import { Paragraph } from "../paragraph";
 import { XmlComponent } from "../xml-components";
 
-import { GridCol, TableGrid } from "./grid";
+import { TableGrid } from "./grid";
 import { TableProperties } from "./properties";
 
 export class Table extends XmlComponent {
@@ -15,7 +15,7 @@ export class Table extends XmlComponent {
         this.root.push(this.properties);
 
         const gridCols: number[] = [];
-        for (let i = 0; i++; i < cols) {
+        for (let i = 0; i < cols; i++) {
             gridCols.push(0);
         }
         this.grid = new TableGrid(gridCols);
@@ -66,7 +66,7 @@ class TableRowProperties extends XmlComponent {
 }
 
 class TableCell extends XmlComponent {
-    public content: XmlComponent;
+    public content: Paragraph;
     private properties: TableCellProperties;
 
     constructor() {

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -1,0 +1,83 @@
+import {XmlComponent, Attributes} from "../xml-components";
+import {Paragraph} from "../paragraph";
+import {TableProperties} from "./properties";
+import {TableGrid, GridCol} from './grid';
+
+export class Table extends XmlComponent {
+    properties: TableProperties;
+    private rows: Array<TableRow>;
+    private grid: TableGrid;
+
+    constructor(rows: number, cols: number) {
+        super('w:tbl');
+        this.properties = new TableProperties();
+        this.root.push(this.properties);
+
+        const gridCols = [];
+        for (let i = 0; i++; i < cols) {
+            gridCols.push(new GridCol());
+        }
+        this.grid = new TableGrid(gridCols);
+        this.root.push(this.grid);
+
+        this.rows = [];
+        for (let i = 0; i < rows; i++) {
+            const cells = [];
+            for (let j = 0; j < cols; j++) {
+                cells.push(new TableCell());
+            }
+            const row = new TableRow(cells);
+            this.rows.push(row);
+            this.root.push(row);
+        }
+    }
+
+    getRow(ix: number): TableRow {
+        return this.rows[ix];
+    }
+}
+
+class TableRow extends XmlComponent {
+    private properties: TableRowProperties;
+    private cells: Array<TableCell>;
+
+    constructor(cells: Array<TableCell>) {
+        super('w:tr');
+        this.properties = new TableRowProperties();
+        this.root.push(this.properties);
+        this.cells = cells;
+        cells.forEach(c => this.root.push(c))
+    }
+
+    getCell(ix: number): TableCell {
+        return this.cells[ix];
+    }
+}
+
+class TableRowProperties extends XmlComponent {
+    constructor() {
+        super('w:trPr');
+    }
+}
+
+class TableCell extends XmlComponent {
+    private properties: TableCellProperties;
+    content: any;
+
+    constructor() {
+        super('w:tc');
+        this.properties = new TableCellProperties();
+        this.root.push(this.properties);
+        this.root.push()
+        // Table cells can have any block-level content, but for now
+        // we only allow a single paragraph:
+        this.content = new Paragraph();
+        this.root.push(this.content);
+    }
+}
+
+class TableCellProperties extends XmlComponent {
+    constructor() {
+        super('w:tcPr');
+    }
+}

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -2,7 +2,7 @@ import { Paragraph } from "../paragraph";
 import { XmlComponent } from "../xml-components";
 
 import { TableGrid } from "./grid";
-import { TableProperties } from "./properties";
+import { TableProperties, widthTypes } from "./properties";
 
 export class Table extends XmlComponent {
     private properties: TableProperties;
@@ -16,7 +16,17 @@ export class Table extends XmlComponent {
 
         const gridCols: number[] = [];
         for (let i = 0; i < cols; i++) {
-            gridCols.push(0);
+            /*
+              0-width columns don't get rendered correctly, so we need
+              to give them some value. A reasonable default would be
+              ~6in / numCols, but if we do that it becomes very hard
+              to resize the table using setWidth, unless the layout
+              algorithm is set to 'fixed'. Instead, the approach here
+              means even in 'auto' layout, setting a width on the
+              table will make it look reasonable, as the layout
+              algorithm will expand columns to fit its content
+             */
+            gridCols.push(1);
         }
         this.grid = new TableGrid(gridCols);
         this.root.push(this.grid);
@@ -39,6 +49,11 @@ export class Table extends XmlComponent {
 
     public getCell(row: number, col: number): TableCell {
         return this.getRow(row).getCell(col);
+    }
+
+    public setWidth(type: widthTypes, width: number | string): Table {
+        this.properties.setWidth(type, width);
+        return this;
     }
 }
 

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -96,7 +96,7 @@ class TableCell extends XmlComponent {
 
     public push(content: Paragraph | Table): TableCell {
         this.root.push(content);
-        return this
+        return this;
     }
 
     public prepForXml(): object {
@@ -106,7 +106,7 @@ class TableCell extends XmlComponent {
         if (!content[content.length - 1]["w:p"]) {
             content.push(new Paragraph().prepForXml());
         }
-        return retval
+        return retval;
     }
 
     public createParagraph(text?: string): Paragraph {

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -23,7 +23,7 @@ export class Table extends XmlComponent {
 
         this.rows = [];
         for (let i = 0; i < rows; i++) {
-            const cells = [];
+            const cells: TableCell[] = [];
             for (let j = 0; j < cols; j++) {
                 cells.push(new TableCell());
             }

--- a/ts/docx/table/index.ts
+++ b/ts/docx/table/index.ts
@@ -1,21 +1,22 @@
-import {XmlComponent, Attributes} from "../xml-components";
-import {Paragraph} from "../paragraph";
-import {TableProperties} from "./properties";
-import {TableGrid, GridCol} from './grid';
+import { Paragraph } from "../paragraph";
+import { XmlComponent } from "../xml-components";
+
+import { GridCol, TableGrid } from "./grid";
+import { TableProperties } from "./properties";
 
 export class Table extends XmlComponent {
-    properties: TableProperties;
-    private rows: Array<TableRow>;
+    private properties: TableProperties;
+    private rows: TableRow[];
     private grid: TableGrid;
 
     constructor(rows: number, cols: number) {
-        super('w:tbl');
+        super("w:tbl");
         this.properties = new TableProperties();
         this.root.push(this.properties);
 
-        const gridCols = [];
+        const gridCols: number[] = [];
         for (let i = 0; i++; i < cols) {
-            gridCols.push(new GridCol());
+            gridCols.push(0);
         }
         this.grid = new TableGrid(gridCols);
         this.root.push(this.grid);
@@ -32,43 +33,46 @@ export class Table extends XmlComponent {
         }
     }
 
-    getRow(ix: number): TableRow {
+    public getRow(ix: number): TableRow {
         return this.rows[ix];
+    }
+
+    public getCell(row: number, col: number): TableCell {
+        return this.getRow(row).getCell(col);
     }
 }
 
 class TableRow extends XmlComponent {
     private properties: TableRowProperties;
-    private cells: Array<TableCell>;
+    private cells: TableCell[];
 
-    constructor(cells: Array<TableCell>) {
-        super('w:tr');
+    constructor(cells: TableCell[]) {
+        super("w:tr");
         this.properties = new TableRowProperties();
         this.root.push(this.properties);
         this.cells = cells;
-        cells.forEach(c => this.root.push(c))
+        cells.forEach((c) => this.root.push(c));
     }
 
-    getCell(ix: number): TableCell {
+    public getCell(ix: number): TableCell {
         return this.cells[ix];
     }
 }
 
 class TableRowProperties extends XmlComponent {
     constructor() {
-        super('w:trPr');
+        super("w:trPr");
     }
 }
 
 class TableCell extends XmlComponent {
+    public content: XmlComponent;
     private properties: TableCellProperties;
-    content: any;
 
     constructor() {
-        super('w:tc');
+        super("w:tc");
         this.properties = new TableCellProperties();
         this.root.push(this.properties);
-        this.root.push()
         // Table cells can have any block-level content, but for now
         // we only allow a single paragraph:
         this.content = new Paragraph();
@@ -78,6 +82,6 @@ class TableCell extends XmlComponent {
 
 class TableCellProperties extends XmlComponent {
     constructor() {
-        super('w:tcPr');
+        super("w:tcPr");
     }
 }

--- a/ts/docx/table/properties.ts
+++ b/ts/docx/table/properties.ts
@@ -1,0 +1,24 @@
+import {XmlComponent, Attributes} from "../xml-components";
+
+export class TableProperties extends XmlComponent {
+    private width: PreferredTableWidth;
+
+    constructor() {
+        super('w:tblPr');
+    }
+
+    setWidth(type: string, w: string) {
+        this.width = new PreferredTableWidth(type, w);
+        this.root.push(this.width);
+    }
+}
+
+class PreferredTableWidth extends XmlComponent {
+    constructor(type: string, w: string) {
+        super('w:tblW');
+        this.root.push(new Attributes({
+            type,
+            w,
+        }))
+    }
+}

--- a/ts/docx/table/properties.ts
+++ b/ts/docx/table/properties.ts
@@ -1,6 +1,6 @@
 import { XmlAttributeComponent, XmlComponent } from "../xml-components";
 
-type widthTypes = "dxa" | "pct" | "nil" | "auto";
+export type widthTypes = "dxa" | "pct" | "nil" | "auto";
 
 export class TableProperties extends XmlComponent {
     constructor() {

--- a/ts/docx/table/properties.ts
+++ b/ts/docx/table/properties.ts
@@ -11,6 +11,11 @@ export class TableProperties extends XmlComponent {
         this.root.push(new PreferredTableWidth(type, w));
         return this;
     }
+
+    public fixedWidthLayout(): TableProperties {
+        this.root.push(new TableLayout("fixed"));
+        return this;
+    }
 }
 
 interface ITableWidth {
@@ -26,5 +31,18 @@ class PreferredTableWidth extends XmlComponent {
     constructor(type: widthTypes, w: number | string) {
         super("w:tblW");
         this.root.push(new TableWidthAttributes({type, w}));
+    }
+}
+
+type tableLayout = "autofit" | "fixed";
+
+class TableLayoutAttributes extends XmlAttributeComponent<{type: tableLayout}> {
+    protected xmlKeys = {type: "w:type"};
+}
+
+class TableLayout extends XmlComponent {
+    constructor(type: tableLayout) {
+        super("w:tblLayout");
+        this.root.push(new TableLayoutAttributes({type}));
     }
 }

--- a/ts/docx/table/properties.ts
+++ b/ts/docx/table/properties.ts
@@ -1,24 +1,30 @@
-import {XmlComponent, Attributes} from "../xml-components";
+import { XmlAttributeComponent, XmlComponent } from "../xml-components";
+
+type widthTypes = "dxa" | "pct" | "nil" | "auto";
 
 export class TableProperties extends XmlComponent {
-    private width: PreferredTableWidth;
-
     constructor() {
-        super('w:tblPr');
+        super("w:tblPr");
     }
 
-    setWidth(type: string, w: string) {
-        this.width = new PreferredTableWidth(type, w);
-        this.root.push(this.width);
+    public setWidth(type: widthTypes, w: number | string): TableProperties {
+        this.root.push(new PreferredTableWidth(type, w));
+        return this;
     }
 }
 
+interface ITableWidth {
+    type: widthTypes;
+    w: number | string;
+}
+
+class TableWidthAttributes extends XmlAttributeComponent<ITableWidth> {
+    protected xmlKeys = {type: "w:type", w: "w:w"};
+}
+
 class PreferredTableWidth extends XmlComponent {
-    constructor(type: string, w: string) {
-        super('w:tblW');
-        this.root.push(new Attributes({
-            type,
-            w,
-        }))
+    constructor(type: widthTypes, w: number | string) {
+        super("w:tblW");
+        this.root.push(new TableWidthAttributes({type, w}));
     }
 }

--- a/ts/test-tsconfig.json
+++ b/ts/test-tsconfig.json
@@ -1,7 +1,12 @@
 {
     "compilerOptions": {
         "target": "es6",
+        "strictNullChecks": true,
+        "sourceMap": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
         "outDir": "../build-tests",
+        "sourceRoot": "./",
         "rootDir": "./",
         "module": "commonjs"
     }

--- a/ts/tests/docx/document/documentTest.ts
+++ b/ts/tests/docx/document/documentTest.ts
@@ -57,7 +57,7 @@ describe("Document", () => {
         });
 
         it("should create a table with the correct dimensions", () => {
-            const table = document.createTable(2, 3);
+            document.createTable(2, 3);
             const body = new Formatter().format(document)["w:document"][1]["w:body"];
             expect(body).to.be.an("array").which.has.length.at.least(1);
             expect(body[0]).to.have.property("w:tbl").which.includes({

--- a/ts/tests/docx/document/documentTest.ts
+++ b/ts/tests/docx/document/documentTest.ts
@@ -46,4 +46,28 @@ describe("Document", () => {
             });
         });
     });
+
+    describe("#createTable", () => {
+        it("should create a new table and append it to body", () => {
+            const table = document.createTable(2, 3);
+            expect(table).to.be.an.instanceof(docx.Table);
+            const body = new Formatter().format(document)["w:document"][1]["w:body"];
+            expect(body).to.be.an("array").which.has.length.at.least(1);
+            expect(body[0]).to.have.property("w:tbl");
+        });
+
+        it("should create a table with the correct dimensions", () => {
+            const table = document.createTable(2, 3);
+            const body = new Formatter().format(document)["w:document"][1]["w:body"];
+            expect(body).to.be.an("array").which.has.length.at.least(1);
+            expect(body[0]).to.have.property("w:tbl").which.includes({
+                "w:tblGrid": [
+                    {"w:gridCol": [{_attr: {"w:w": 1}}]},
+                    {"w:gridCol": [{_attr: {"w:w": 1}}]},
+                    {"w:gridCol": [{_attr: {"w:w": 1}}]},
+                ],
+            });
+            expect(body[0]["w:tbl"].filter((x) => x["w:tr"])).to.have.length(2);
+        });
+    });
 });

--- a/ts/tests/docx/table/testGrid.ts
+++ b/ts/tests/docx/table/testGrid.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import { GridCol, TableGrid } from "../../../docx/table/grid";
+import { Formatter } from "../../../export/formatter";
+
+describe("GridCol", () => {
+    describe("#constructor", () => {
+        it("sets the width attribute to the value given", () => {
+            const grid = new GridCol(1234);
+            const tree = new Formatter().format(grid);
+            expect(tree).to.deep.equal({
+                "w:gridCol": [{_attr: {"w:w": 1234}}],
+            });
+        });
+
+        it("does not set a width attribute if not given", () => {
+            const grid = new GridCol();
+            const tree = new Formatter().format(grid);
+            expect(tree).to.deep.equal({
+                "w:gridCol": [{_attr: {}}],
+            });
+        });
+    });
+});
+
+describe("TableGrid", () => {
+    describe("#constructor", () => {
+        it("creates a column for each width given", () => {
+            const grid = new TableGrid([1234, 321, 123]);
+            const tree = new Formatter().format(grid);
+            expect(tree).to.deep.equal({
+                "w:tblGrid": [
+                    {"w:gridCol": [{_attr: {"w:w": 1234}}]},
+                    {"w:gridCol": [{_attr: {"w:w": 321}}]},
+                    {"w:gridCol": [{_attr: {"w:w": 123}}]},
+                ],
+            });
+        });
+
+        it("does not set a width attribute if not given", () => {
+            const grid = new GridCol();
+            const tree = new Formatter().format(grid);
+            expect(tree).to.deep.equal({
+                "w:gridCol": [{_attr: {}}],
+            });
+        });
+    });
+});

--- a/ts/tests/docx/table/testGrid.ts
+++ b/ts/tests/docx/table/testGrid.ts
@@ -15,9 +15,7 @@ describe("GridCol", () => {
         it("does not set a width attribute if not given", () => {
             const grid = new GridCol();
             const tree = new Formatter().format(grid);
-            expect(tree).to.deep.equal({
-                "w:gridCol": [{_attr: {}}],
-            });
+            expect(tree).to.deep.equal({"w:gridCol": []});
         });
     });
 });
@@ -33,14 +31,6 @@ describe("TableGrid", () => {
                     {"w:gridCol": [{_attr: {"w:w": 321}}]},
                     {"w:gridCol": [{_attr: {"w:w": 123}}]},
                 ],
-            });
-        });
-
-        it("does not set a width attribute if not given", () => {
-            const grid = new GridCol();
-            const tree = new Formatter().format(grid);
-            expect(tree).to.deep.equal({
-                "w:gridCol": [{_attr: {}}],
             });
         });
     });

--- a/ts/tests/docx/table/testProperties.ts
+++ b/ts/tests/docx/table/testProperties.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+import { TableProperties } from "../../../docx/table/properties";
+import { Formatter } from "../../../export/formatter";
+
+describe("TableProperties", () => {
+    describe("#constructor", () => {
+        it("creates an initially empty property object", () => {
+            const tp = new TableProperties();
+            const tree = new Formatter().format(tp);
+            expect(tree).to.deep.equal({"w:tblPr": []});
+        });
+    });
+
+    describe("#setWidth", () => {
+        it("adds a table width property", () => {
+            const tp = new TableProperties().setWidth("dxa", 1234);
+            const tree = new Formatter().format(tp);
+            expect(tree).to.deep.equal({
+                "w:tblPr": [
+                    {"w:tblW": [{_attr: {"w:type": "dxa", "w:w": 1234}}]},
+                ],
+            });
+        });
+    });
+});

--- a/ts/tests/docx/table/testProperties.ts
+++ b/ts/tests/docx/table/testProperties.ts
@@ -22,4 +22,16 @@ describe("TableProperties", () => {
             });
         });
     });
+
+    describe("#fixedWidthLayout", () => {
+        it("sets the table to fixed width layout", () => {
+            const tp = new TableProperties().fixedWidthLayout();
+            const tree = new Formatter().format(tp);
+            expect(tree).to.deep.equal({
+                "w:tblPr": [
+                    {"w:tblLayout": [{_attr: {"w:type": "fixed"}}]},
+                ],
+            });
+        });
+    });
 });

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -12,8 +12,8 @@ describe("Table", () => {
                 "w:tbl": [
                     {"w:tblPr": []},
                     {"w:tblGrid": [
-                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
-                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 1}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 1}}]},
                     ]},
                     {"w:tr": [{"w:trPr": []}, cell, cell]},
                     {"w:tr": [{"w:trPr": []}, cell, cell]},
@@ -42,8 +42,8 @@ describe("Table", () => {
                 "w:tbl": [
                     {"w:tblPr": []},
                     {"w:tblGrid": [
-                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
-                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 1}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 1}}]},
                     ]},
                     {"w:tr": [{"w:trPr": []}, cell("A1"), cell("B1")]},
                     {"w:tr": [{"w:trPr": []}, cell("A2"), cell("B2")]},
@@ -71,11 +71,24 @@ describe("Table", () => {
                 "w:tbl": [
                     {"w:tblPr": []},
                     {"w:tblGrid": [
-                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
-                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 1}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 1}}]},
                     ]},
                     {"w:tr": [{"w:trPr": []}, cell("A1"), cell("B1")]},
                     {"w:tr": [{"w:trPr": []}, cell("A2"), cell("B2")]},
+                ],
+            });
+        });
+    });
+
+    describe("#setWidth", () => {
+        it("sets the preferred width on the table", () => {
+            const table = new Table(2, 2).setWidth("pct", 1000)
+            const tree = new Formatter().format(table);
+            expect(tree).to.have.property("w:tbl").which.is.an("array").with.has.length.at.least(1);
+            expect(tree["w:tbl"][0]).to.deep.equal({
+                "w:tblPr": [
+                    {"w:tblW": [{_attr: {"w:type": "pct", "w:w": 1000}}]},
                 ],
             });
         });

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -84,7 +84,7 @@ describe("Table", () => {
 
     describe("#setWidth", () => {
         it("sets the preferred width on the table", () => {
-            const table = new Table(2, 2).setWidth("pct", 1000)
+            const table = new Table(2, 2).setWidth("pct", 1000);
             const tree = new Formatter().format(table);
             expect(tree).to.have.property("w:tbl").which.is.an("array").with.has.length.at.least(1);
             expect(tree["w:tbl"][0]).to.deep.equal({

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -27,10 +27,10 @@ describe("Table", () => {
     describe("#getRow and Row#getCell", () => {
         it("returns the correct row", () => {
             const table = new Table(2, 2);
-            table.getRow(0).getCell(0).push(new Paragraph("A1"));
-            table.getRow(0).getCell(1).push(new Paragraph("B1"));
-            table.getRow(1).getCell(0).push(new Paragraph("A2"));
-            table.getRow(1).getCell(1).push(new Paragraph("B2"));
+            table.getRow(0).getCell(0).addContent(new Paragraph("A1"));
+            table.getRow(0).getCell(1).addContent(new Paragraph("B1"));
+            table.getRow(1).getCell(0).addContent(new Paragraph("A2"));
+            table.getRow(1).getCell(1).addContent(new Paragraph("B2"));
             const tree = new Formatter().format(table);
             const cell = (c) => ({"w:tc": [
                 {"w:tcPr": []},
@@ -56,10 +56,10 @@ describe("Table", () => {
     describe("#getCell", () => {
         it("returns the correct cell", () => {
             const table = new Table(2, 2);
-            table.getCell(0, 0).push(new Paragraph("A1"));
-            table.getCell(0, 1).push(new Paragraph("B1"));
-            table.getCell(1, 0).push(new Paragraph("A2"));
-            table.getCell(1, 1).push(new Paragraph("B2"));
+            table.getCell(0, 0).addContent(new Paragraph("A1"));
+            table.getCell(0, 1).addContent(new Paragraph("B1"));
+            table.getCell(1, 0).addContent(new Paragraph("A2"));
+            table.getCell(1, 1).addContent(new Paragraph("B2"));
             const tree = new Formatter().format(table);
             const cell = (c) => ({"w:tc": [
                 {"w:tcPr": []},
@@ -127,7 +127,7 @@ describe("Table", () => {
 
             it("inserts a paragraph at the end of the cell even if it has a child table", () => {
                 const parentTable = new Table(1, 1);
-                parentTable.getCell(0, 0).push(new Table(1, 1));
+                parentTable.getCell(0, 0).addContent(new Table(1, 1));
                 const tree = new Formatter().format(parentTable);
                 expect(tree).to.have.property("w:tbl").which.is.an("array");
                 const row = tree["w:tbl"].find((x) => x["w:tr"]);
@@ -142,7 +142,7 @@ describe("Table", () => {
 
             it("does not insert a paragraph if it already ends with one", () => {
                 const parentTable = new Table(1, 1);
-                parentTable.getCell(0, 0).push(new Paragraph("Hello"));
+                parentTable.getCell(0, 0).addContent(new Paragraph("Hello"));
                 const tree = new Formatter().format(parentTable);
                 expect(tree).to.have.property("w:tbl").which.is.an("array");
                 const row = tree["w:tbl"].find((x) => x["w:tr"]);

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -159,5 +159,27 @@ describe("Table", () => {
                 });
             });
         });
+
+        describe("#createParagraph", () => {
+            it("inserts a new paragraph in the cell", () => {
+                const table = new Table(1, 1);
+                const para = table.getCell(0, 0).createParagraph("Test paragraph");
+                expect(para).to.be.an.instanceof(Paragraph);
+                const tree = new Formatter().format(table);
+                expect(tree).to.have.property("w:tbl").which.is.an("array");
+                const row = tree["w:tbl"].find((x) => x["w:tr"]);
+                expect(row).not.to.be.undefined;
+                expect(row["w:tr"]).to.be.an("array").which.has.length.at.least(1);
+                expect(row["w:tr"].find((x) => x["w:tc"])).to.deep.equal({
+                    "w:tc": [
+                        {"w:tcPr": []},
+                        {"w:p": [
+                            {"w:pPr": []},
+                            {"w:r": [{"w:rPr": []}, {"w:t": ["Test paragraph"]}]},
+                        ]},
+                    ],
+                });
+            });
+        });
     });
 });

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -51,4 +51,33 @@ describe("Table", () => {
             });
         });
     });
+
+    describe("#getCell", () => {
+        it("returns the correct cell", () => {
+            const table = new Table(2, 2);
+            table.getCell(0, 0).content.createTextRun("A1");
+            table.getCell(0, 1).content.createTextRun("B1");
+            table.getCell(1, 0).content.createTextRun("A2");
+            table.getCell(1, 1).content.createTextRun("B2");
+            const tree = new Formatter().format(table);
+            const cell = (c) => ({"w:tc": [
+                {"w:tcPr": []},
+                {"w:p": [
+                    {"w:pPr": []},
+                    {"w:r": [{"w:rPr": []}, {"w:t": [c]}]},
+                ]},
+            ]});
+            expect(tree).to.deep.equal({
+                "w:tbl": [
+                    {"w:tblPr": []},
+                    {"w:tblGrid": [
+                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                    ]},
+                    {"w:tr": [{"w:trPr": []}, cell("A1"), cell("B1")]},
+                    {"w:tr": [{"w:trPr": []}, cell("A2"), cell("B2")]},
+                ],
+            });
+        });
+    });
 });

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -1,0 +1,54 @@
+import { expect } from "chai";
+import { Table } from "../../../docx/table";
+import { Formatter } from "../../../export/formatter";
+
+describe("Table", () => {
+    describe("#constructor", () => {
+        it("creates a table with the correct number of rows and columns", () => {
+            const table = new Table(3, 2);
+            const tree = new Formatter().format(table);
+            const cell = {"w:tc": [{"w:tcPr": []}, {"w:p": [{"w:pPr": []}]}]};
+            expect(tree).to.deep.equal({
+                "w:tbl": [
+                    {"w:tblPr": []},
+                    {"w:tblGrid": [
+                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                    ]},
+                    {"w:tr": [{"w:trPr": []}, cell, cell]},
+                    {"w:tr": [{"w:trPr": []}, cell, cell]},
+                    {"w:tr": [{"w:trPr": []}, cell, cell]},
+                ],
+            });
+        });
+    });
+
+    describe("#getRow and Row#getCell", () => {
+        it("returns the correct row", () => {
+            const table = new Table(2, 2);
+            table.getRow(0).getCell(0).content.createTextRun("A1");
+            table.getRow(0).getCell(1).content.createTextRun("B1");
+            table.getRow(1).getCell(0).content.createTextRun("A2");
+            table.getRow(1).getCell(1).content.createTextRun("B2");
+            const tree = new Formatter().format(table);
+            const cell = (c) => ({"w:tc": [
+                {"w:tcPr": []},
+                {"w:p": [
+                    {"w:pPr": []},
+                    {"w:r": [{"w:rPr": []}, {"w:t": [c]}]},
+                ]},
+            ]});
+            expect(tree).to.deep.equal({
+                "w:tbl": [
+                    {"w:tblPr": []},
+                    {"w:tblGrid": [
+                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                        {"w:gridCol": [{_attr: {"w:w": 0}}]},
+                    ]},
+                    {"w:tr": [{"w:trPr": []}, cell("A1"), cell("B1")]},
+                    {"w:tr": [{"w:trPr": []}, cell("A2"), cell("B2")]},
+                ],
+            });
+        });
+    });
+});

--- a/ts/tests/docx/table/testTable.ts
+++ b/ts/tests/docx/table/testTable.ts
@@ -93,4 +93,17 @@ describe("Table", () => {
             });
         });
     });
+
+    describe("#fixedWidthLayout", () => {
+        it("sets the table to fixed width layout", () => {
+            const table = new Table(2, 2).fixedWidthLayout();
+            const tree = new Formatter().format(table);
+            expect(tree).to.have.property("w:tbl").which.is.an("array").with.has.length.at.least(1);
+            expect(tree["w:tbl"][0]).to.deep.equal({
+                "w:tblPr": [
+                    {"w:tblLayout": [{_attr: {"w:type": "fixed"}}]},
+                ],
+            });
+        });
+    });
 });


### PR DESCRIPTION
I think the table implementation is at a point where it can be merged. There are tests for everything, the api is nice to use, and most importantly, the output works correctly for the few cases I've tried. The implementation follows the spec, but there are possibly some quirks not captured by it (e.g., there was an issue where if tables don't specify column widths, LibreOffice won't render them as tables [already fixed]). Here's how you would use it:

```js
const table = doc.createTable(2, 3);
table.getCell(0, 0).createParagraph("This is the top-left");
table.getCell(0, 1).createParagraph().createTextRun("Heading 1 - italics").italic();
table.getCell(0, 2).createParagraph().createTextRun("Heading 2 - bold").bold();

table.getCell(1, 0).push(new Table(2, 3));  // Nested tables!!
table.getCell(1, 1).createParagraph()
    .createTextRun('Some content here, underlined')
    .underline('single');
table.getCell(1, 2).push(new Paragraph('This also works'));
```