### PR TITLE
NPM fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "ts",
-    "build"
+    "build",
+    "template"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,8 @@
     "clippy"
   ],
   "dependencies": {
-    "@types/app-root-path": "^1.2.4",
     "@types/archiver": "^0.15.37",
     "@types/express": "^4.0.35",
-    "app-root-path": "^2.0.1",
     "archiver": "^1.3.0",
     "xml": "^1.0.1"
   },

--- a/ts/export/packer/packer.ts
+++ b/ts/export/packer/packer.ts
@@ -1,5 +1,5 @@
-import * as appRoot from "app-root-path";
 import * as archiver from "archiver";
+import * as path from "path";
 import * as xml from "xml";
 import { Document } from "../../docx";
 import { Numbering } from "../../numbering";
@@ -7,6 +7,8 @@ import { Properties } from "../../properties";
 import { Styles } from "../../styles";
 import { DefaultStylesFactory } from "../../styles/factory";
 import { Formatter } from "../formatter";
+
+const templatePath = path.resolve(__dirname, "../../../template");
 
 export abstract class Packer {
     protected archive: any;
@@ -53,12 +55,12 @@ export abstract class Packer {
         this.archive.pipe(output);
         this.archive.glob("**", {
             expand: true,
-            cwd: appRoot.path + "/template",
+            cwd: templatePath,
         });
 
         this.archive.glob("**/.rels", {
             expand: true,
-            cwd: appRoot.path + "/template",
+            cwd: templatePath,
         });
 
         const xmlDocument = xml(this.formatter.format(this.document));


### PR DESCRIPTION
This is a small fix to a couple of issues that I've encountered now that I'm using the library from NPM:

- Make sure to include the docx template in the NPM bundle
- Remove `app-root-path` and use `path.resolve` (full rationale in felipeochoa/docx@c7b7b58)