### PR TITLE
add keepLines and keepNext support for paragraph formatting

### DIFF
--- a/ts/docx/paragraph/formatting.ts
+++ b/ts/docx/paragraph/formatting.ts
@@ -1,6 +1,7 @@
 export { Alignment } from "./alignment";
 export { ThematicBreak } from "./border";
 export { Indent } from "./indent";
+export { KeepLines, KeepNext } from "./keep";
 export { PageBreak } from "./page-break";
 export { ParagraphProperties } from "./properties";
 export { ISpacingProperties, Spacing } from "./spacing";

--- a/ts/docx/paragraph/index.ts
+++ b/ts/docx/paragraph/index.ts
@@ -8,6 +8,7 @@ import { XmlComponent } from "../xml-components";
 import { Alignment } from "./alignment";
 import { ThematicBreak } from "./border";
 import { Indent } from "./indent";
+import { KeepLines, KeepNext } from "./keep";
 import { PageBreak } from "./page-break";
 import { ParagraphProperties } from "./properties";
 import { ISpacingProperties, Spacing } from "./spacing";
@@ -140,4 +141,14 @@ export class Paragraph extends XmlComponent {
         this.properties.push(new Spacing(params));
         return this;
     };
+
+    public keepNext(): Paragraph {
+        this.properties.push(new KeepNext());
+        return this;
+    }
+
+    public keepLines(): Paragraph {
+        this.properties.push(new KeepLines());
+        return this;
+    }
 }

--- a/ts/docx/paragraph/keep.ts
+++ b/ts/docx/paragraph/keep.ts
@@ -1,0 +1,13 @@
+import { XmlComponent } from "../xml-components";
+
+export class KeepLines extends XmlComponent {
+    constructor() {
+        super("w:keepLines");
+    }
+}
+
+export class KeepNext extends XmlComponent {
+    constructor() {
+        super("w:keepNext");
+    }
+}

--- a/ts/numbering/level.ts
+++ b/ts/numbering/level.ts
@@ -205,6 +205,16 @@ class LevelBase extends XmlComponent {
         this.addParagraphProperty(new paragraph.Spacing(params));
         return this;
     };
+
+    public keepNext(): Level {
+        this.addParagraphProperty(new paragraph.KeepNext());
+        return this;
+    }
+
+    public keepLines(): Level {
+        this.addParagraphProperty(new paragraph.KeepLines());
+        return this;
+    }
 }
 
 export class Level extends LevelBase {

--- a/ts/styles/style/index.ts
+++ b/ts/styles/style/index.ts
@@ -180,6 +180,16 @@ export class ParagraphStyle extends Style {
         this.addParagraphProperty(new paragraph.Spacing(params));
         return this;
     };
+
+    public keepNext(): ParagraphStyle {
+        this.addParagraphProperty(new paragraph.KeepNext());
+        return this;
+    }
+
+    public keepLines(): ParagraphStyle {
+        this.addParagraphProperty(new paragraph.KeepLines());
+        return this;
+    }
 }
 
 export class HeadingStyle extends ParagraphStyle {

--- a/ts/tests/docx/paragraph/paragraphTests.ts
+++ b/ts/tests/docx/paragraph/paragraphTests.ts
@@ -269,4 +269,24 @@ describe("Paragraph", () => {
             });
         });
     });
+
+    describe("#keepLines", () => {
+        it("should set the paragraph keepLines sub-component", () => {
+            paragraph.keepLines();
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.deep.equal({
+                "w:p": [{"w:pPr": [{"w:keepLines": []}]}],
+            });
+        });
+    });
+
+    describe("#keepNext", () => {
+        it("should set the paragraph keepNext sub-component", () => {
+            paragraph.keepNext();
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.deep.equal({
+                "w:p": [{"w:pPr": [{"w:keepNext": []}]}],
+            });
+        });
+    });
 });

--- a/ts/tests/numberingTest.ts
+++ b/ts/tests/numberingTest.ts
@@ -222,6 +222,26 @@ describe("AbstractNumbering", () => {
                     ],
                 });
             });
+
+            it("#keepLines", () => {
+                const abstractNumbering = new AbstractNumbering(1);
+                const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.")
+                    .keepLines();
+                const tree = new Formatter().format(level);
+                expect(tree["w:lvl"]).to.include({
+                    "w:pPr": [{"w:keepLines": []}],
+                });
+            });
+
+            it("#keepNext", () => {
+                const abstractNumbering = new AbstractNumbering(1);
+                const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.")
+                    .keepNext();
+                const tree = new Formatter().format(level);
+                expect(tree["w:lvl"]).to.include({
+                    "w:pPr": [{"w:keepNext": []}],
+                });
+            });
         });
 
         describe("formatting methods: run properties", () => {

--- a/ts/tests/stylesTest.ts
+++ b/ts/tests/stylesTest.ts
@@ -326,6 +326,32 @@ describe("ParagraphStyle", () => {
                 ],
             });
         });
+
+        it("#keepLines", () => {
+            const style = new ParagraphStyle("myStyleId")
+                .keepLines();
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    {_attr: {"w:type": "paragraph", "w:styleId": "myStyleId"}},
+                    {"w:pPr": [{"w:keepLines": []}]},
+                    {"w:rPr": []},
+                ],
+            });
+        });
+
+        it("#keepNext", () => {
+            const style = new ParagraphStyle("myStyleId")
+                .keepNext();
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    {_attr: {"w:type": "paragraph", "w:styleId": "myStyleId"}},
+                    {"w:pPr": [{"w:keepNext": []}]},
+                    {"w:rPr": []},
+                ],
+            });
+        });
     });
 
     describe("formatting methods: run properties", () => {


### PR DESCRIPTION
This commit adds it to the three places where paragraph formatting can
be applied right now (directly on the paragraph, paragraph styles, and
bullets/numbering styles). I'm separately adding an entry to the wiki
regarding what these methods do (widow/orphan control)