### PR TITLE
Fix page/thematic breaks

### DIFF
--- a/ts/docx/paragraph/index.ts
+++ b/ts/docx/paragraph/index.ts
@@ -98,7 +98,7 @@ export class Paragraph extends XmlComponent {
     }
 
     public thematicBreak(): Paragraph {
-        this.root.push(new ThematicBreak());
+        this.properties.push(new ThematicBreak());
         return this;
     }
 

--- a/ts/docx/paragraph/index.ts
+++ b/ts/docx/paragraph/index.ts
@@ -98,12 +98,12 @@ export class Paragraph extends XmlComponent {
     }
 
     public thematicBreak(): Paragraph {
-        this.properties.push(new ThematicBreak());
+        this.root.push(new ThematicBreak());
         return this;
     }
 
     public pageBreak(): Paragraph {
-        this.properties.push(new PageBreak());
+        this.root.push(new PageBreak());
         return this;
     }
 

--- a/ts/tests/docx/paragraph/paragraphTests.ts
+++ b/ts/tests/docx/paragraph/paragraphTests.ts
@@ -144,12 +144,10 @@ describe("Paragraph", () => {
             const tree = new Formatter().format(paragraph);
             expect(tree).to.deep.equal({
                 "w:p": [{
-                    "w:pPr": [{
-                        "w:r": [
-                            {"w:rPr": []},
-                            {"w:br": [{_attr: {"w:type": "page"}}]},
-                        ],
-                    }],
+                    "w:r": [
+                        {"w:rPr": []},
+                        {"w:br": [{_attr: {"w:type": "page"}}]},
+                    ],
                 }],
             });
         });


### PR DESCRIPTION
These items are not paragraph properties, but part of the content of the paragraph.

I'm suggesting this fix, but I've not been able to build and test docx because of the error below, so please could you either direct me to how to get around the error or run the tests before merging?

```
ts/docx/xml-components/default-attributes.ts(20,32): error TS2536: Type 'string' cannot be used to index type 'AttributeMap<T>'.
```