### PR TITLE
Allow indent to use other options than left and hanging

### DIFF
--- a/ts/docx/paragraph/indent.ts
+++ b/ts/docx/paragraph/indent.ts
@@ -3,22 +3,25 @@ import { XmlAttributeComponent, XmlComponent } from "../xml-components";
 interface IIndentAttributesProperties {
     left?: number;
     hanging?: number;
+    firstLine?: number;
+    start?: number;
+    end?: number;
 }
 
 class IndentAttributes extends XmlAttributeComponent<IIndentAttributesProperties> {
     protected xmlKeys = {
         left: "w:left",
         hanging: "w:hanging",
+        firstLine: "w:firstLine",
+        start: "w:start",
+        end: "w:end",
     };
 }
 
 export class Indent extends XmlComponent {
 
-    constructor(left: number, hanging?: number) {
+    constructor(attrs: object) {
         super("w:ind");
-        this.root.push(new IndentAttributes({
-            left: left,
-            hanging: hanging,
-        }));
+        this.root.push(new IndentAttributes(attrs));
     }
 }

--- a/ts/docx/paragraph/index.ts
+++ b/ts/docx/paragraph/index.ts
@@ -134,8 +134,8 @@ export class Paragraph extends XmlComponent {
         return this;
     }
 
-    public indent(start: number, hanging?: number): Paragraph {
-        this.properties.push(new Indent(start, hanging));
+    public indent(attrs: object): Paragraph {
+        this.properties.push(new Indent(attrs));
         return this;
     }
 

--- a/ts/docx/paragraph/paragraph.spec.ts
+++ b/ts/docx/paragraph/paragraph.spec.ts
@@ -241,7 +241,7 @@ describe("Paragraph", () => {
 
     describe("#indent", () => {
         it("should set the paragraph indent to the given values", () => {
-            paragraph.indent(720);
+            paragraph.indent({ left: 720 });
             const tree = new Formatter().format(paragraph);
             expect(tree).to.deep.equal({
                 "w:p": [

--- a/ts/numbering/index.ts
+++ b/ts/numbering/index.ts
@@ -35,39 +35,39 @@ export class Numbering extends XmlComponent {
         const abstractNumbering = this.createAbstractNumbering();
 
         abstractNumbering.createLevel(0, "bullet", "•", "left")
-            .addParagraphProperty(new Indent(720, 360))
+            .addParagraphProperty(new Indent({ left: 720, hanging: 360 }))
             .addRunProperty(new RunFonts("Symbol", "default"));
 
         abstractNumbering.createLevel(1, "bullet", "o", "left")
-            .addParagraphProperty(new Indent(1440, 360))
+            .addParagraphProperty(new Indent({ left: 1440, hanging: 360 }))
             .addRunProperty(new RunFonts("Courier New", "default"));
 
         abstractNumbering.createLevel(2, "bullet", "•", "left")
-            .addParagraphProperty(new Indent(2160, 360))
+            .addParagraphProperty(new Indent({ left: 2160, hanging: 360 }))
             .addRunProperty(new RunFonts("Wingdings", "default"));
 
         abstractNumbering.createLevel(3, "bullet", "•", "left")
-            .addParagraphProperty(new Indent(2880, 360))
+            .addParagraphProperty(new Indent({ left: 2880, hanging: 360 }))
             .addRunProperty(new RunFonts("Symbol", "default"));
 
         abstractNumbering.createLevel(4, "bullet", "o", "left")
-            .addParagraphProperty(new Indent(3600, 360))
+            .addParagraphProperty(new Indent({ left: 3600, hanging: 360 }))
             .addRunProperty(new RunFonts("Courier New", "default"));
 
         abstractNumbering.createLevel(5, "bullet", "•", "left")
-            .addParagraphProperty(new Indent(4320, 360))
+            .addParagraphProperty(new Indent({ left: 4320, hanging: 360 }))
             .addRunProperty(new RunFonts("Wingdings", "default"));
 
         abstractNumbering.createLevel(6, "bullet", "•", "left")
-            .addParagraphProperty(new Indent(5040, 360))
+            .addParagraphProperty(new Indent({ left: 5040, hanging: 360 }))
             .addRunProperty(new RunFonts("Symbol", "default"));
 
         abstractNumbering.createLevel(7, "bullet", "o", "left")
-            .addParagraphProperty(new Indent(5760, 360))
+            .addParagraphProperty(new Indent({ left: 5760, hanging: 360 }))
             .addRunProperty(new RunFonts("Courier New", "default"));
 
         abstractNumbering.createLevel(8, "bullet", "•", "left")
-            .addParagraphProperty(new Indent(6480, 360))
+            .addParagraphProperty(new Indent({ left: 6480, hanging: 360 }))
             .addRunProperty(new RunFonts("Wingdings", "default"));
 
         this.createConcreteNumbering(abstractNumbering);

--- a/ts/numbering/level.ts
+++ b/ts/numbering/level.ts
@@ -196,8 +196,8 @@ export class LevelBase extends XmlComponent {
         return this;
     }
 
-    public indent(left: number, hanging?: number): Level {
-        this.addParagraphProperty(new paragraph.Indent(left, hanging));
+    public indent(attrs: object): Level {
+        this.addParagraphProperty(new paragraph.Indent(attrs));
         return this;
     }
 

--- a/ts/numbering/numbering.spec.ts
+++ b/ts/numbering/numbering.spec.ts
@@ -111,7 +111,7 @@ describe("AbstractNumbering", () => {
             it("#indent", () => {
                 const abstractNumbering = new AbstractNumbering(1);
                 const level = abstractNumbering.createLevel(0, "lowerLetter", "%0.")
-                    .indent(720);
+                    .indent({ left: 720 });
                 const tree = new Formatter().format(level);
                 expect(tree["w:lvl"]).to.include({
                     "w:pPr": [{"w:ind": [{_attr: {"w:left": 720}}]}],

--- a/ts/styles/style/index.ts
+++ b/ts/styles/style/index.ts
@@ -171,8 +171,8 @@ export class ParagraphStyle extends Style {
         return this;
     }
 
-    public indent(left: number, hanging?: number): ParagraphStyle {
-        this.addParagraphProperty(new paragraph.Indent(left, hanging));
+    public indent(attrs: object): ParagraphStyle {
+        this.addParagraphProperty(new paragraph.Indent(attrs));
         return this;
     }
 

--- a/ts/styles/styles.spec.ts
+++ b/ts/styles/styles.spec.ts
@@ -185,7 +185,7 @@ describe("ParagraphStyle", () => {
     describe("formatting methods: paragraph properties", () => {
         it("#indent", () => {
             const style = new ParagraphStyle("myStyleId")
-                .indent(720);
+                .indent({ left: 720 });
             const tree = new Formatter().format(style);
             expect(tree).to.deep.equal({
                 "w:style": [


### PR DESCRIPTION
This is a breaking change. Existing code using indent will break when padding in the number for left.

If you don't like this breaking change I can submit another PR that just adds a 3rd parameter after `hanging` for the `firstLine` attribute. This attribute is the most common after `left` IMO, and the attribute I need. Book manuscripts indent the first line of each paragraph. I made this bigger change because I felt like 3 arguments, all optional, starts to get messy.

Please advise.