### PR TITLE
Adding the ability to indent first line only in paragraphs

### DIFF
--- a/ts/docx/paragraph/indent.ts
+++ b/ts/docx/paragraph/indent.ts
@@ -3,22 +3,25 @@ import { XmlAttributeComponent, XmlComponent } from "../xml-components";
 interface IIndentAttributesProperties {
     left?: number;
     hanging?: number;
+    firstLine?: number;
 }
 
 class IndentAttributes extends XmlAttributeComponent<IIndentAttributesProperties> {
     protected xmlKeys = {
         left: "w:left",
         hanging: "w:hanging",
+        firstLine: "w:firstLine",
     };
 }
 
 export class Indent extends XmlComponent {
 
-    constructor(left: number, hanging?: number) {
+    constructor(left: number, hanging?: number, firstLine?: number) {
         super("w:ind");
         this.root.push(new IndentAttributes({
             left: left,
             hanging: hanging,
+            firstLine: firstLine,
         }));
     }
 }

--- a/ts/styles/style/index.ts
+++ b/ts/styles/style/index.ts
@@ -171,8 +171,8 @@ export class ParagraphStyle extends Style {
         return this;
     }
 
-    public indent(left: number, hanging?: number): ParagraphStyle {
-        this.addParagraphProperty(new paragraph.Indent(left, hanging));
+    public indent(left: number, hanging?: number, firstLine?: number): ParagraphStyle {
+        this.addParagraphProperty(new paragraph.Indent(left, hanging, firstLine));
         return this;
     }
 


### PR DESCRIPTION
This is a backwards compatible fix while a better (but breaking) fix is here https://github.com/dolanmiu/docx/pull/44.