### PR TITLE
Added generic stream packer

### DIFF
--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -1,3 +1,4 @@
 export * from "./packer/local";
 export * from "./packer/express";
 export * from "./packer/packer";
+export * from "./packer/stream";

--- a/src/export/packer/compiler.ts
+++ b/src/export/packer/compiler.ts
@@ -1,6 +1,6 @@
 import * as archiver from "archiver";
 import * as express from "express";
-import * as fs from "fs";
+import { Writable } from "stream";
 import * as xml from "xml";
 
 import { File } from "file";
@@ -19,7 +19,7 @@ export class Compiler {
         });
     }
 
-    public async compile(output: fs.WriteStream | express.Response): Promise<void> {
+    public async compile(output: Writable | express.Response): Promise<void> {
         this.archive.pipe(output);
 
         const xmlDocument = xml(this.formatter.format(this.file.Document), true);

--- a/src/export/packer/stream.ts
+++ b/src/export/packer/stream.ts
@@ -1,0 +1,25 @@
+import { Readable, Transform } from "stream";
+import { File } from "../../file";
+import { Compiler } from "./compiler";
+import { IPacker } from "./packer";
+
+class Pipe extends Transform {
+    public _transform(chunk: Buffer | string, encoding: string, callback: () => void): void {
+        this.push(chunk, encoding);
+        callback();
+    }
+}
+
+export class StreamPacker implements IPacker {
+    private readonly compiler: Compiler;
+
+    constructor(file: File) {
+        this.compiler = new Compiler(file);
+    }
+
+    public pack(): Readable {
+        const pipe = new Pipe();
+        this.compiler.compile(pipe);
+        return pipe;
+    }
+}


### PR DESCRIPTION
This way `docx` doesn't have to explicitly create a new packer for every use case. (In fact, you could easily implement the express and fs packers on top of this one)