### PR TITLE
image scaling add rounding

### DIFF
--- a/src/file/drawing/inline/inline.ts
+++ b/src/file/drawing/inline/inline.ts
@@ -35,8 +35,8 @@ export class Inline extends XmlComponent {
     }
 
     public scale(factorX: number, factorY: number): void {
-        const newX = this.dimensions.emus.x * factorX;
-        const newY = this.dimensions.emus.y * factorY;
+        const newX = Math.round(this.dimensions.emus.x * factorX);
+        const newY = Math.round(this.dimensions.emus.y * factorY);
 
         this.extent.setXY(newX, newY);
         this.graphic.setXY(newX, newY);

--- a/src/file/paragraph/paragraph.ts
+++ b/src/file/paragraph/paragraph.ts
@@ -69,6 +69,11 @@ export class Paragraph extends XmlComponent {
         return this;
     }
 
+    public heading6(): Paragraph {
+        this.properties.push(new Style("Heading6"));
+        return this;
+    }
+
     public title(): Paragraph {
         this.properties.push(new Style("Title"));
         return this;


### PR DESCRIPTION
Found that sometimes after using image scaling documents where diplayed as broken by MS Word. It was down to image scaling units having  .5 values. After adding this fix no problems accured. Also exposed heading6 method.