### PR TITLE
Let fonts suit for more characters

### DIFF
--- a/src/file/numbering/numbering.spec.ts
+++ b/src/file/numbering/numbering.spec.ts
@@ -297,7 +297,9 @@ describe("AbstractNumbering", () => {
                 const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.").font("Times");
                 const tree = new Formatter().format(level);
                 expect(tree["w:lvl"]).to.include({
-                    "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] }],
+                    "w:rPr": [
+                        { "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] },
+                    ],
                 });
             });
 

--- a/src/file/numbering/numbering.spec.ts
+++ b/src/file/numbering/numbering.spec.ts
@@ -34,7 +34,7 @@ describe("Numbering", () => {
                 ]);
                 // Once chai 4.0.0 lands and #644 is resolved, we can add the following to the test:
                 // {"w:lvlText": [{"_attr": {"w:val": "•"}}]},
-                // {"w:rPr": [{"w:rFonts": [{"_attr": {"w:ascii": "Symbol", "w:hAnsi": "Symbol", "w:hint": "default"}}]}]},
+                // {"w:rPr": [{"w:rFonts": [{"_attr": {"w:ascii": "Symbol", "w:cs": "Symbol", "w:eastAsia": "Symbol", "w:hAnsi": "Symbol", "w:hint": "default"}}]}]},
                 // {"w:pPr": [{"_attr": {}},
                 //            {"w:ind": [{"_attr": {"w:left": 720, "w:hanging": 360}}]}]},
             });
@@ -297,7 +297,7 @@ describe("AbstractNumbering", () => {
                 const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.").font("Times");
                 const tree = new Formatter().format(level);
                 expect(tree["w:lvl"]).to.include({
-                    "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:hAnsi": "Times" } }] }],
+                    "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] }],
                 });
             });
 

--- a/src/file/paragraph/run/run-fonts.spec.ts
+++ b/src/file/paragraph/run/run-fonts.spec.ts
@@ -8,14 +8,14 @@ describe("RunFonts", () => {
         it("uses the font name for both ascii and hAnsi", () => {
             const tree = new Formatter().format(new RunFonts("Times"));
             expect(tree).to.deep.equal({
-                "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:hAnsi": "Times" } }],
+                "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }],
             });
         });
 
         it("uses hint if given", () => {
             const tree = new Formatter().format(new RunFonts("Times", "default"));
             expect(tree).to.deep.equal({
-                "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:hAnsi": "Times", "w:hint": "default" } }],
+                "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times", "w:hint": "default" } }],
             });
         });
     });

--- a/src/file/paragraph/run/run-fonts.spec.ts
+++ b/src/file/paragraph/run/run-fonts.spec.ts
@@ -15,7 +15,9 @@ describe("RunFonts", () => {
         it("uses hint if given", () => {
             const tree = new Formatter().format(new RunFonts("Times", "default"));
             expect(tree).to.deep.equal({
-                "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times", "w:hint": "default" } }],
+                "w:rFonts": [
+                    { _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times", "w:hint": "default" } },
+                ],
             });
         });
     });

--- a/src/file/paragraph/run/run-fonts.ts
+++ b/src/file/paragraph/run/run-fonts.ts
@@ -2,6 +2,8 @@ import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
 
 interface IRunFontAttributesProperties {
     ascii: string;
+    cs: string;
+    eastAsia: string;
     hAnsi: string;
     hint?: string;
 }
@@ -9,6 +11,8 @@ interface IRunFontAttributesProperties {
 class RunFontAttributes extends XmlAttributeComponent<IRunFontAttributesProperties> {
     protected xmlKeys = {
         ascii: "w:ascii",
+        cs: "w:cs",
+        eastAsia: "w:eastAsia",
         hAnsi: "w:hAnsi",
         hint: "w:hint",
     };
@@ -20,6 +24,8 @@ export class RunFonts extends XmlComponent {
         this.root.push(
             new RunFontAttributes({
                 ascii: ascii,
+                cs: ascii,
+                eastAsia: ascii,
                 hAnsi: ascii,
                 hint: hint,
             }),

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -108,7 +108,7 @@ describe("Run", () => {
             run.font("Times");
             const tree = new Formatter().format(run);
             expect(tree).to.deep.equal({
-                "w:r": [{ "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:hAnsi": "Times" } }] }] }],
+                "w:r": [{ "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] }] }],
             });
         });
     });

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -108,7 +108,13 @@ describe("Run", () => {
             run.font("Times");
             const tree = new Formatter().format(run);
             expect(tree).to.deep.equal({
-                "w:r": [{ "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] }] }],
+                "w:r": [
+                    {
+                        "w:rPr": [
+                            { "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] },
+                        ],
+                    },
+                ],
             });
         });
     });

--- a/src/file/styles/styles.spec.ts
+++ b/src/file/styles/styles.spec.ts
@@ -459,7 +459,11 @@ describe("ParagraphStyle", () => {
                 "w:style": [
                     { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
                     { "w:pPr": [] },
-                    { "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] }] },
+                    {
+                        "w:rPr": [
+                            { "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] },
+                        ],
+                    },
                 ],
             });
         });

--- a/src/file/styles/styles.spec.ts
+++ b/src/file/styles/styles.spec.ts
@@ -459,7 +459,7 @@ describe("ParagraphStyle", () => {
                 "w:style": [
                     { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
                     { "w:pPr": [] },
-                    { "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:hAnsi": "Times" } }] }] },
+                    { "w:rPr": [{ "w:rFonts": [{ _attr: { "w:ascii": "Times", "w:cs": "Times", "w:eastAsia": "Times", "w:hAnsi": "Times" } }] }] },
                 ],
             });
         });


### PR DESCRIPTION
add support for `w:eastAsia` and `w:cs`

[Reference](http://officeopenxml.com/WPtextFonts.php)