### PR TITLE
add addGridspan to TableRow

### DIFF
--- a/src/file/table/table.ts
+++ b/src/file/table/table.ts
@@ -81,6 +81,15 @@ export class TableRow extends XmlComponent {
     public getCell(ix: number): TableCell {
         return this.cells[ix];
     }
+
+    public addGridSpan(ix: number, cellSpan: number): TableCell {
+        const remainCell = this.cells[ix];
+        remainCell.cellProperties.addGridSpan(cellSpan);
+        this.cells.splice(ix + 1, cellSpan - 1);
+        this.root.splice(ix + 2, cellSpan - 1);
+
+        return remainCell
+    }
 }
 
 export class TableRowProperties extends XmlComponent {

--- a/src/file/table/table.ts
+++ b/src/file/table/table.ts
@@ -88,7 +88,7 @@ export class TableRow extends XmlComponent {
         this.cells.splice(ix + 1, cellSpan - 1);
         this.root.splice(ix + 2, cellSpan - 1);
 
-        return remainCell
+        return remainCell;
     }
 }
 


### PR DESCRIPTION
When add a gridspan to a table cell, the cells after it should be removed. Because we can't deal with other cells in `TableCellProperties`, I try to add a `addGridspan` in `TableRow`.

It's still a temporary solution because it's not safe when add gridspan and vMerge to a cell at same time, maybe we can have a better way to build a table?