### PR TITLE
Added character spacing attribute

### DIFF
--- a/src/file/paragraph/run/formatting.ts
+++ b/src/file/paragraph/run/formatting.ts
@@ -25,6 +25,17 @@ export class BoldComplexScript extends XmlComponent {
     }
 }
 
+export class CharacterSpacing extends XmlComponent {
+    constructor(value: number) {
+        super("w:spacing");
+        this.root.push(
+            new Attributes({
+                val: value,
+            }),
+        );
+    }
+}
+
 export class Italics extends XmlComponent {
     constructor() {
         super("w:i");

--- a/src/file/styles/style/index.ts
+++ b/src/file/styles/style/index.ts
@@ -133,6 +133,11 @@ export class ParagraphStyle extends Style {
         return this;
     }
 
+    public characterSpacing(value: number): ParagraphStyle {
+        this.addRunProperty(new formatting.CharacterSpacing(value));
+        return this;
+    }
+
     // --------------------- Paragraph formatting ------------------------ //
 
     public center(): ParagraphStyle {

--- a/src/file/styles/styles.spec.ts
+++ b/src/file/styles/styles.spec.ts
@@ -219,6 +219,20 @@ describe("ParagraphStyle", () => {
             });
         });
 
+        it("#character spacing", () => {
+            const style = new ParagraphStyle("myStyleId").characterSpacing(24);
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
+                    { "w:pPr": [] },
+                    {
+                        "w:rPr": [{ "w:spacing": [{ _attr: { "w:val": 24 } }] }],
+                    },
+                ],
+            });
+        });
+
         it("#left", () => {
             const style = new ParagraphStyle("myStyleId").left();
             const tree = new Formatter().format(style);


### PR DESCRIPTION
Closes #157 

- [x] Added char spacing attribute (_Character Spacing Adjustment (rPr) not Spacing Between Lines and Above/Below Paragraph (pPr)_)
- [x] Added test case

```ts
const style = new ParagraphStyle("myStyleId").characterSpacing(24);
```

Could you bump npm after the merge ?