### PR TITLE
Bugfix - Correct default section options

### DIFF
--- a/demo/demo16.ts
+++ b/demo/demo16.ts
@@ -1,7 +1,7 @@
 // Multiple sections and headers
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { Document, Packer, PageNumberFormat, PageOrientation, Paragraph } from "../build";
+import { Document, Packer, PageNumberFormat, PageOrientation, Paragraph, TextRun } from "../build";
 
 const doc = new Document();
 
@@ -40,6 +40,40 @@ doc.addSection({
 });
 
 doc.createParagraph("hello in landscape");
+
+const header2 = doc.createHeader();
+const pageNumber = new TextRun("Page number: ").pageNumber(); 
+header2.createParagraph().addRun(pageNumber);
+
+doc.addSection({
+    headers: {
+        default: header2,
+    },
+    orientation: PageOrientation.PORTRAIT,
+});
+
+doc.createParagraph("Page number in the header must be 2, because it continues from the previous section.");
+
+doc.addSection({
+    headers: {
+        default: header2,
+    },
+    pageNumberFormatType: PageNumberFormat.UPPER_ROMAN,
+    orientation: PageOrientation.PORTRAIT,
+});
+
+doc.createParagraph("Page number in the header must be III, because it continues from the previous section, but is defined as upper roman.");
+
+doc.addSection({
+    headers: {
+        default: header2,
+    },
+    pageNumberFormatType: PageNumberFormat.DECIMAL,
+    pageNumberStart: 25,
+    orientation: PageOrientation.PORTRAIT,
+});
+
+doc.createParagraph("Page number in the header must be 25, because it is defined to start at 25 and to be decimal in this section.");
 
 const packer = new Packer();
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -158,7 +158,8 @@ _Source: https://github.com/dolanmiu/docx/blob/master/demo/demo15.ts_
 
 ## Sections
 
-Example of how sections work. Sections allow multiple headers and footers, and `landscape`/`portrait` inside the same document
+Example of how sections work. Sections allow multiple headers and footers, and `landscape`/`portrait` inside the same document. 
+Also you can have different page number formats and starts for different sections.
 
 [Example](https://raw.githubusercontent.com/dolanmiu/docx/master/demo/demo16.ts ":include")
 

--- a/docs/usage/headers-and-footers.md
+++ b/docs/usage/headers-and-footers.md
@@ -37,8 +37,12 @@ Also all the supported section properties are implemented according to: http://o
 
     // Add new section with another header and footer
     doc.addSection({
-      headerId: header.Header.ReferenceId,
-      footerId: footer.Footer.ReferenceId,
+      headers: {
+        default: header 
+      },
+      footers: {
+        default: footer 
+      },
       pageNumberStart: 1,
       pageNumberFormatType: docx.PageNumberFormat.DECIMAL,
     });

--- a/src/file/document/body/body.spec.ts
+++ b/src/file/document/body/body.spec.ts
@@ -17,7 +17,7 @@ describe("Body", () => {
             expect(formatted)
                 .to.have.property("w:sectPr")
                 .and.to.be.an.instanceof(Array);
-            expect(formatted["w:sectPr"]).to.have.length(5);
+            expect(formatted["w:sectPr"]).to.have.length(4);
         });
     });
 
@@ -76,7 +76,6 @@ describe("Body", () => {
                                             },
                                             { "w:cols": [{ _attr: { "w:space": 708 } }] },
                                             { "w:docGrid": [{ _attr: { "w:linePitch": 360 } }] },
-                                            { "w:pgNumType": [{ _attr: { "w:fmt": "decimal" } }] },
                                         ],
                                     },
                                 ],
@@ -104,7 +103,6 @@ describe("Body", () => {
                             },
                             { "w:cols": [{ _attr: { "w:space": 708 } }] },
                             { "w:docGrid": [{ _attr: { "w:linePitch": 360 } }] },
-                            { "w:pgNumType": [{ _attr: { "w:fmt": "decimal" } }] },
                         ],
                     },
                 ],

--- a/src/file/document/body/section-properties/section-properties.spec.ts
+++ b/src/file/document/body/section-properties/section-properties.spec.ts
@@ -88,7 +88,6 @@ describe("SectionProperties", () => {
             });
             expect(tree["w:sectPr"][2]).to.deep.equal({ "w:cols": [{ _attr: { "w:space": 708 } }] });
             expect(tree["w:sectPr"][3]).to.deep.equal({ "w:docGrid": [{ _attr: { "w:linePitch": 360 } }] });
-            expect(tree["w:sectPr"][4]).to.deep.equal({ "w:pgNumType": [{ _attr: { "w:fmt": "decimal" } }] });
         });
 
         it("should create section properties with changed options", () => {
@@ -182,6 +181,26 @@ describe("SectionProperties", () => {
             expect(pgBorders).to.deep.equal({
                 "w:pgBorders": [{ _attr: { "w:offsetFrom": "page" } }],
             });
+        });
+
+        it("should create section properties with page number type, but without start attribute", () => {
+            const properties = new SectionProperties({
+                pageNumberFormatType: PageNumberFormat.UPPER_ROMAN,
+            });
+            const tree = new Formatter().format(properties);
+            expect(Object.keys(tree)).to.deep.equal(["w:sectPr"]);
+            const pgNumType = tree["w:sectPr"].find((item) => item["w:pgNumType"] !== undefined);
+            expect(pgNumType).to.deep.equal({
+                "w:pgNumType": [{ _attr: { "w:fmt": "upperRoman" } }],
+            });
+        });
+
+        it("should create section properties without page number type", () => {
+            const properties = new SectionProperties({});
+            const tree = new Formatter().format(properties);
+            expect(Object.keys(tree)).to.deep.equal(["w:sectPr"]);
+            const pgNumType = tree["w:sectPr"].find((item) => item["w:pgNumType"] !== undefined);
+            expect(pgNumType).to.equal(undefined);
         });
     });
 });

--- a/src/file/document/body/section-properties/section-properties.ts
+++ b/src/file/document/body/section-properties/section-properties.ts
@@ -14,7 +14,7 @@ import { HeaderReference } from "./header-reference/header-reference";
 import { IPageBordersOptions, PageBorders } from "./page-border";
 import { PageMargin } from "./page-margin/page-margin";
 import { IPageMarginAttributes } from "./page-margin/page-margin-attributes";
-import { IPageNumberTypeAttributes, PageNumberFormat, PageNumberType } from "./page-number";
+import { IPageNumberTypeAttributes, PageNumberType } from "./page-number";
 import { PageSize } from "./page-size/page-size";
 import { IPageSizeAttributes, PageOrientation } from "./page-size/page-size-attributes";
 import { TitlePage } from "./title-page/title-page";
@@ -69,7 +69,7 @@ export class SectionProperties extends XmlComponent {
             orientation = PageOrientation.PORTRAIT,
             headers,
             footers,
-            pageNumberFormatType = PageNumberFormat.DECIMAL,
+            pageNumberFormatType,
             pageNumberStart,
             pageBorders,
             pageBorderTop,
@@ -88,7 +88,9 @@ export class SectionProperties extends XmlComponent {
         this.addHeaders(headers);
         this.addFooters(footers);
 
-        this.root.push(new PageNumberType(pageNumberStart, pageNumberFormatType));
+        if (pageNumberStart || pageNumberFormatType) {
+            this.root.push(new PageNumberType(pageNumberStart, pageNumberFormatType));
+        }
 
         if (pageBorders || pageBorderTop || pageBorderRight || pageBorderBottom || pageBorderLeft) {
             this.root.push(


### PR DESCRIPTION
The page number type attribute of the sections was always been created, leading Word to always reset page numbers to zero in new sections.
The page number type DECIMAL is already default in Word, there is no need to force this to be the default option in the default section, like it was.
Demo 16 was updated to show how page number types format and start work.
Improvements in headers and footers docs