### PR TITLE
Update xml-component.ts

### DIFF
--- a/src/file/xml-components/xml-component.ts
+++ b/src/file/xml-components/xml-component.ts
@@ -27,7 +27,7 @@ export abstract class XmlComponent extends BaseXmlComponent {
             })
             .filter((comp) => comp !== undefined); // Exclude undefined
         return {
-            [this.rootKey]: children,
+            [this.rootKey]: children.length ? children : null,
         };
     }
 


### PR DESCRIPTION
Empty XML nodes are not closed and can have spaces in them which adds unwanted spaces in Word documents when indenting. This fixes #213.