### PR TITLE
Fix getting started docs for v4 packer.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ import * as docx from "docx";
 ## Basic Usage
 
 ```js
+var fs = require("fs");
 var docx = require("docx");
 
 // Create document
@@ -41,11 +42,12 @@ paragraph.addRun(new docx.TextRun("Lorem Ipsum Foo Bar"));
 doc.addParagraph(paragraph);
 
 // Used to export the file into a .docx file
-var exporter = new docx.LocalPacker(doc);
+var packer = new docx.Packer();
+packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My First Document.docx", buffer);
+});
 
-exporter.pack("My First Document");
-
-// Done! A file called 'My First Document.docx' will be in your file system if you used LocalPacker
+// Done! A file called 'My First Document.docx' will be in your file system.
 ```
 
 ## Honoured Mentions


### PR DESCRIPTION
I think it's better if these docs work for v4 as that's what new users will get via npm install.