### PR TITLE
Add OutlineLevel Paragraph property

### DIFF
--- a/demo/demo39.ts
+++ b/demo/demo39.ts
@@ -1,0 +1,33 @@
+// Scaling images
+// Import from 'docx' rather than '../build' if you install from npm
+import * as fs from "fs";
+import { Document, Packer, PageNumberFormat, TextRun } from "../build";
+
+const doc = new Document(
+    {},
+    {
+        pageNumberStart: 1,
+        pageNumberFormatType: PageNumberFormat.DECIMAL,
+    },
+);
+
+doc.Header.createParagraph("Foo Bar corp. ")
+    .addRun(new TextRun("Page Number ").pageNumber())
+    .addRun(new TextRun(" to ").numberOfTotalPages());
+
+doc.Footer.createParagraph("Foo Bar corp. ")
+    .center()
+    .addRun(new TextRun("Page Number: ").pageNumber())
+    .addRun(new TextRun(" to ").numberOfTotalPages());
+
+doc.createParagraph("Hello World 1").pageBreak();
+doc.createParagraph("Hello World 2").pageBreak();
+doc.createParagraph("Hello World 3").pageBreak();
+doc.createParagraph("Hello World 4").pageBreak();
+doc.createParagraph("Hello World 5").pageBreak();
+
+const packer = new Packer();
+
+packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -17,6 +17,7 @@
     * [Numbering](usage/numbering.md)
 	* [Tab Stops](usage/tab-stops.md)
     * [Table of Contents](usage/table-of-contents.md)
+    * [Page Numbers](usage/page-numbers.md)
 	* Styling
         * [Styling with JS](usage/styling-with-js.md)
         * [Styling with XML](usage/styling-with-xml.md)

--- a/docs/usage/page-numbers.md
+++ b/docs/usage/page-numbers.md
@@ -1,0 +1,66 @@
+# Page Numbers
+
+> This feature allows you to set page numbers on each page
+
+?> **Note:** This feature only works on Headers and Footers
+
+```ts
+doc.Header.createParagraph().addRun(new TextRun("Page Number: ").pageNumber()).addRun(new TextRun("to ").numberOfTotalPages());
+```
+
+## Current page number
+
+To get the current page number, call the `.pageNumber()` method on a `TextRun`. Then add the newly created `TextRun` into a paragraph
+
+```ts
+pageNumber();
+```
+
+For example:
+
+```ts
+const currentPageRun = new TextRun("Current Page Number: ").pageNumber();
+paragraph.addRun(currentPageRun);
+```
+
+## Total number of pages
+
+```ts
+numberOfTotalPages();
+```
+
+For example:
+
+```ts
+const lastPage = new TextRun("Total Page Number: ").numberOfTotalPages();
+paragraph.addRun(lastPage);
+```
+
+
+## Both
+
+You can combine the two to get "Page 2 of 10" effect:
+
+```ts
+const currentPageRun = new TextRun("Page ").pageNumber();
+const lastPage = new TextRun("of ").numberOfTotalPages();
+
+paragraph.addRun(currentPageRun);
+paragraph.addRun(lastPage);
+```
+
+Or:
+
+```ts
+doc.Header.createParagraph().addRun(new TextRun("Page ").pageNumber()).addRun(new TextRun("of ").numberOfTotalPages());
+```
+
+## Examples
+
+### Simple Example
+
+Adding page numbers to Header and Footer
+
+[Example](https://raw.githubusercontent.com/dolanmiu/docx/master/demo/demo39.ts ":include")
+
+_Source: https://github.com/dolanmiu/docx/blob/master/demo/demo39.ts_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docx",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Generate .docx documents with JavaScript (formerly Office-Clippy)",
   "main": "build/index.js",
   "scripts": {

--- a/src/file/paragraph/links/index.ts
+++ b/src/file/paragraph/links/index.ts
@@ -1,2 +1,3 @@
 export * from "./hyperlink";
 export * from "./bookmark";
+export * from "./outline-level";

--- a/src/file/paragraph/links/outline-level.spec.ts
+++ b/src/file/paragraph/links/outline-level.spec.ts
@@ -1,0 +1,23 @@
+import { assert } from "chai";
+
+import { Utility } from "tests/utility";
+
+import { OutlineLevel } from "./outline-level";
+
+describe("ParagraphOutlineLevel", () => {
+    let outlineLevel: OutlineLevel;
+
+    describe("#constructor()", () => {
+        it("should create an outlineLevel with given value", () => {
+            outlineLevel = new OutlineLevel("0");
+            const newJson = Utility.jsonify(outlineLevel);
+            assert.equal(newJson.root[0].root.val, "0");
+        });
+
+        it("should create an outlineLevel with blank val", () => {
+            outlineLevel = new OutlineLevel("");
+            const newJson = Utility.jsonify(outlineLevel);
+            assert.equal(newJson.root[0].root.val, "");
+        });
+    });
+});

--- a/src/file/paragraph/links/outline-level.ts
+++ b/src/file/paragraph/links/outline-level.ts
@@ -1,0 +1,17 @@
+// http://officeopenxml.com/WPparagraph.php
+import { Attributes, XmlComponent } from "file/xml-components";
+
+export class OutlineLevel extends XmlComponent {
+    public readonly level: string;
+
+    constructor(level: string) {
+        super("w:outlineLvl");
+        this.level = level;
+        this.root.push(
+            new Attributes({
+                val: level,
+            }),
+        );
+    }
+
+}

--- a/src/file/paragraph/links/outline-level.ts
+++ b/src/file/paragraph/links/outline-level.ts
@@ -13,5 +13,4 @@ export class OutlineLevel extends XmlComponent {
             }),
         );
     }
-
 }

--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -666,4 +666,18 @@ describe("Paragraph", () => {
             });
         });
     });
+
+    describe("#outlineLevel", () => {
+        it("should set paragraph outline level to the given value", () => {
+            paragraph.outlineLevel("0");
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.deep.equal({
+                "w:p": [
+                    {
+                        "w:pPr": [{ "w:outlineLvl": [{ _attr: { "w:val": "0" } }] }],
+                    },
+                ],
+            });
+        });
+    });
 });

--- a/src/file/paragraph/paragraph.ts
+++ b/src/file/paragraph/paragraph.ts
@@ -14,7 +14,7 @@ import { ContextualSpacing, ISpacingProperties, Spacing } from "./formatting/spa
 import { Style } from "./formatting/style";
 import { CenterTabStop, LeaderType, LeftTabStop, MaxRightTabStop, RightTabStop } from "./formatting/tab-stop";
 import { NumberProperties } from "./formatting/unordered-list";
-import { Bookmark, Hyperlink } from "./links";
+import { Bookmark, Hyperlink, OutlineLevel } from "./links";
 import { ParagraphProperties } from "./properties";
 import { PictureRun, Run, SequentialIdentifier, TextRun } from "./run";
 
@@ -243,6 +243,11 @@ export class Paragraph extends XmlComponent {
 
     public addSequentialIdentifier(identifier: string): Paragraph {
         this.root.push(new SequentialIdentifier(identifier));
+        return this;
+    }
+
+    public outlineLevel(level: string): Paragraph {
+        this.properties.push(new OutlineLevel(level));
         return this;
     }
 }

--- a/src/file/paragraph/run/page-number.spec.ts
+++ b/src/file/paragraph/run/page-number.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+
+import { Formatter } from "export/formatter";
+
+import { NumberOfPages, Page } from "./page-number";
+
+describe("Page", () => {
+    describe("#constructor()", () => {
+        it("uses the font name for both ascii and hAnsi", () => {
+            const tree = new Formatter().format(new Page());
+            expect(tree).to.deep.equal({ "w:instrText": [{ _attr: { "xml:space": "preserve" } }, "PAGE"] });
+        });
+    });
+});
+
+describe("NumberOfPages", () => {
+    describe("#constructor()", () => {
+        it("uses the font name for both ascii and hAnsi", () => {
+            const tree = new Formatter().format(new NumberOfPages());
+            expect(tree).to.deep.equal({ "w:instrText": [{ _attr: { "xml:space": "preserve" } }, "NUMPAGES"] });
+        });
+    });
+});

--- a/src/file/paragraph/run/page-number.ts
+++ b/src/file/paragraph/run/page-number.ts
@@ -12,3 +12,11 @@ export class Page extends XmlComponent {
         this.root.push("PAGE");
     }
 }
+
+export class NumberOfPages extends XmlComponent {
+    constructor() {
+        super("w:instrText");
+        this.root.push(new TextAttributes({ space: SpaceType.PRESERVE }));
+        this.root.push("NUMPAGES");
+    }
+}

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -156,6 +156,38 @@ describe("Run", () => {
         });
     });
 
+    describe("#numberOfTotalPages", () => {
+        it("should set the run to the RTL mode", () => {
+            run.numberOfTotalPages();
+            const tree = new Formatter().format(run);
+            expect(tree).to.deep.equal({
+                "w:r": [
+                    { "w:rPr": [] },
+                    { "w:fldChar": [{ _attr: { "w:fldCharType": "begin" } }] },
+                    { "w:instrText": [{ _attr: { "xml:space": "preserve" } }, "NUMPAGES"] },
+                    { "w:fldChar": [{ _attr: { "w:fldCharType": "separate" } }] },
+                    { "w:fldChar": [{ _attr: { "w:fldCharType": "end" } }] },
+                ],
+            });
+        });
+    });
+
+    describe("#pageNumber", () => {
+        it("should set the run to the RTL mode", () => {
+            run.pageNumber();
+            const tree = new Formatter().format(run);
+            expect(tree).to.deep.equal({
+                "w:r": [
+                    { "w:rPr": [] },
+                    { "w:fldChar": [{ _attr: { "w:fldCharType": "begin" } }] },
+                    { "w:instrText": [{ _attr: { "xml:space": "preserve" } }, "PAGE"] },
+                    { "w:fldChar": [{ _attr: { "w:fldCharType": "separate" } }] },
+                    { "w:fldChar": [{ _attr: { "w:fldCharType": "end" } }] },
+                ],
+            });
+        });
+    });
+
     describe("#style", () => {
         it("should set the style to the given styleId", () => {
             run.style("myRunStyle");

--- a/src/file/paragraph/run/run.ts
+++ b/src/file/paragraph/run/run.ts
@@ -14,7 +14,7 @@ import {
     SizeComplexScript,
     Strike,
 } from "./formatting";
-import { Page } from "./page-number";
+import { NumberOfPages, Page } from "./page-number";
 import { RunProperties } from "./properties";
 import { RunFonts } from "./run-fonts";
 import { SubScript, SuperScript } from "./script";
@@ -79,6 +79,14 @@ export class Run extends XmlComponent {
     public pageNumber(): Run {
         this.root.push(new Begin());
         this.root.push(new Page());
+        this.root.push(new Separate());
+        this.root.push(new End());
+        return this;
+    }
+
+    public numberOfTotalPages(): Run {
+        this.root.push(new Begin());
+        this.root.push(new NumberOfPages());
         this.root.push(new Separate());
         this.root.push(new End());
         return this;


### PR DESCRIPTION
Hi! 
We were working on TOC and we've seen that it doesn't work in LibreOffice (as @kkoomen said in [#232](https://github.com/dolanmiu/docx/issues/232#issuecomment-451654405)).
We find out that a solution could be setting the property "outlineLvl" for paragraph.

Something like:
```
const toc: TableOfContents = new TableOfContents('Index', {
   hyperlink: true,
   headingStyleRange: '1-5'
});
this.doc.addTableOfContents(toc);

const paragraph: Paragraph = this.doc.createParagraph('Chapter 1').heading1();
paragraph.outlineLevel('0');
```

What do you think about?
