### PR TITLE
dont run coverage if publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "mocha-webpack \"src/**/*.ts\"",
     "test.coverage": "nyc npm test",
     "test.watch": "npm test -- --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build --production",
     "lint": "tslint --project .",
     "build": "npm run webpack && npm run fix-types",
     "tsc": "rimraf ./build && tsc -p .",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -22,14 +22,17 @@ module.exports = {
                 test: /\.ts$/,
                 loaders: ["awesome-typescript-loader"],
             },
-            {
-                // For coverage testing
-                test: /\.(ts)/,
-                include: path.resolve("src"),
-                loader: "istanbul-instrumenter-loader",
-                enforce: "post",
-                exclude: [/node_modules/],
-            },
+            // For coverage testing
+            ...(process.env.NODE_ENV !== "production"
+                ? [{
+                    test: /\.(ts)/,
+                    include: path.resolve("src"),
+                    loader: "istanbul-instrumenter-loader",
+                    enforce: "post",
+                    exclude: [/node_modules/],
+                }]
+                : []
+            )
         ],
     },
 


### PR DESCRIPTION
istanbul-instrumenter-loader is running on _every_ build. This means coverage paths are ending up in the published built module - this causes CSP to fail due to strings such as `"C:\\Users\\Dolan\\Documents\\docx\\src\\index.ts"` in the built module.