### PR TITLE
Table pagination: add cantSplit and tblHeader row properties

### DIFF
--- a/src/file/table/table-row/table-row-properties.spec.ts
+++ b/src/file/table/table-row/table-row-properties.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { Formatter } from "export/formatter";
+import { TableRowProperties } from "./table-row-properties";
+
+describe("TableRowProperties", () => {
+    describe("#constructor", () => {
+        it("creates an initially empty property object", () => {
+            const rowProperties = new TableRowProperties();
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({ "w:trPr": [] });
+        });
+    });
+
+    describe("#setCantSplit", () => {
+        it("sets cantSplit to avoid row been paginated", () => {
+            const rowProperties = new TableRowProperties();
+            rowProperties.setCantSplit();
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({ "w:trPr": [{ "w:cantSplit": [{ _attr: { "w:val": true } }] }] });
+        });
+    });
+
+    describe("#setTableHeader", () => {
+        it("sets row as table header (repeat row on each page of table)", () => {
+            const rowProperties = new TableRowProperties();
+            rowProperties.setTableHeader();
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({ "w:trPr": [{ "w:tblHeader": [{ _attr: { "w:val": true } }] }] });
+        });
+    });
+});

--- a/src/file/table/table-row/table-row-properties.ts
+++ b/src/file/table/table-row/table-row-properties.ts
@@ -1,7 +1,41 @@
-import { XmlComponent } from "file/xml-components";
+import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
 
 export class TableRowProperties extends XmlComponent {
     constructor() {
         super("w:trPr");
+    }
+
+    public setCantSplit(): TableRowProperties {
+        this.root.push(new CantSplit());
+
+        return this;
+    }
+
+    public setTableHeader(): TableRowProperties {
+        this.root.push(new TableHeader());
+
+        return this;
+    }
+}
+
+class CantSplitAttributes extends XmlAttributeComponent<{ readonly val: boolean }> {
+    protected readonly xmlKeys = { val: "w:val" };
+}
+
+export class CantSplit extends XmlComponent {
+    constructor() {
+        super("w:cantSplit");
+        this.root.push(new CantSplitAttributes({ val: true }));
+    }
+}
+
+class TableHeaderAttributes extends XmlAttributeComponent<{ readonly val: boolean }> {
+    protected readonly xmlKeys = { val: "w:val" };
+}
+
+export class TableHeader extends XmlComponent {
+    constructor() {
+        super("w:tblHeader");
+        this.root.push(new TableHeaderAttributes({ val: true }));
     }
 }

--- a/src/file/table/table-row/table-row.ts
+++ b/src/file/table/table-row/table-row.ts
@@ -37,4 +37,16 @@ export class TableRow extends XmlComponent {
 
         return this.addGridSpan(startIndex, cellSpan);
     }
+
+    public setCantSplit(): TableRow {
+        this.properties.setCantSplit();
+
+        return this;
+    }
+
+    public setTableHeader(): TableRow {
+        this.properties.setTableHeader();
+
+        return this;
+    }
 }


### PR DESCRIPTION
Added two properties for TableRow: 

- **cantSplit** (prevents the contents of the row from breaking across multiple pages)
- **tblHeader** (the current row should be repeated at the top each new page on which the table is displayed)

Example:
```
table.getRow(0).setCantSplit();
table.getRow(0).setTableHeader();
```

Closes #263 