### PR TITLE
Cell borders on Google Docs + set cell width

### DIFF
--- a/src/file/table/table-cell/table-cell-components.ts
+++ b/src/file/table/table-cell/table-cell-components.ts
@@ -66,6 +66,22 @@ export class TableCellBorders extends XmlComponent {
 
         return this;
     }
+
+    public addLeftBorder(style: BorderStyle, size: number, color: string): TableCellBorders {
+        const left = new BaseTableCellBorder("w:left");
+        left.setProperties(style, size, color);
+        this.root.push(left);
+
+        return this;
+    }
+
+    public addRightBorder(style: BorderStyle, size: number, color: string): TableCellBorders {
+        const right = new BaseTableCellBorder("w:right");
+        right.setProperties(style, size, color);
+        this.root.push(right);
+
+        return this;
+    }
 }
 
 /**

--- a/src/file/table/table-cell/table-cell.spec.ts
+++ b/src/file/table/table-cell/table-cell.spec.ts
@@ -102,12 +102,58 @@ describe("TableCellBorders", () => {
             });
         });
 
+        it("should add left border", () => {
+            const tb = new TableCellBorders();
+            tb.addLeftBorder(BorderStyle.THICK, 3, "FF00FF");
+
+            const tree = new Formatter().format(tb);
+            expect(tree).to.deep.equal({
+                "w:tcBorders": [
+                    {
+                        "w:left": [
+                            {
+                                _attr: {
+                                    "w:color": "FF00FF",
+                                    "w:sz": 3,
+                                    "w:val": "thick",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it("should add right border", () => {
+            const tb = new TableCellBorders();
+            tb.addRightBorder(BorderStyle.THICK, 3, "FF00FF");
+
+            const tree = new Formatter().format(tb);
+            expect(tree).to.deep.equal({
+                "w:tcBorders": [
+                    {
+                        "w:right": [
+                            {
+                                _attr: {
+                                    "w:color": "FF00FF",
+                                    "w:sz": 3,
+                                    "w:val": "thick",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
         it("should add multiple borders", () => {
             const tb = new TableCellBorders();
             tb.addTopBorder(BorderStyle.DOTTED, 1, "FF00FF");
             tb.addEndBorder(BorderStyle.THICK, 3, "FF00FF");
             tb.addBottomBorder(BorderStyle.DOUBLE, 1, "FF00FF");
             tb.addStartBorder(BorderStyle.SINGLE, 2, "FF00FF");
+            tb.addLeftBorder(BorderStyle.SINGLE, 2, "FF00FF");
+            tb.addRightBorder(BorderStyle.SINGLE, 2, "FF00FF");
 
             const tree = new Formatter().format(tb);
             expect(tree).to.deep.equal({
@@ -147,6 +193,28 @@ describe("TableCellBorders", () => {
                     },
                     {
                         "w:start": [
+                            {
+                                _attr: {
+                                    "w:color": "FF00FF",
+                                    "w:sz": 2,
+                                    "w:val": "single",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "w:left": [
+                            {
+                                _attr: {
+                                    "w:color": "FF00FF",
+                                    "w:sz": 2,
+                                    "w:val": "single",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "w:right": [
                             {
                                 _attr: {
                                     "w:color": "FF00FF",

--- a/src/file/table/table-cell/table-cell.ts
+++ b/src/file/table/table-cell/table-cell.ts
@@ -61,4 +61,8 @@ export class TableCell extends XmlComponent {
     public get Borders(): TableCellBorders {
         return this.properties.Borders;
     }
+
+    public get Properties(): TableCellProperties {
+        return this.properties;
+    }
 }


### PR DESCRIPTION
**Cell left and right borders on Google Docs**
Word uses start (_w:start_) and end (_w:end_) properties for customizing left and right borders. Google Docs, instead, uses left (_w:left_) and right (_w:right_) properties

_Example_

for Word:
`cell.Borders.addStartBorder(BorderStyle.NONE, 0, 'ffffff');`

for Google Docs:
`cell.Borders.addLeftBorder(BorderStyle.NONE, 0, 'ffffff');`

**Set cell width**
Add Properties on TableCell in order to set cell width (maybe refers to #180?)

_Example_

`table.getCell(0,0).Properties.setWidth(100, WidthType.DXA);`

