### PR TITLE
Select styles that will go into TOC

### DIFF
--- a/src/file/styles/style/paragraph-style.spec.ts
+++ b/src/file/styles/style/paragraph-style.spec.ts
@@ -258,6 +258,18 @@ describe("ParagraphStyle", () => {
                 ],
             });
         });
+
+        it("#outlineLevel", () => {
+            const style = new ParagraphStyle("myStyleId").outlineLevel("1");
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
+                    { "w:pPr": [{ "w:outlineLvl": [{ _attr: { "w:val": "1" } }] }] },
+                    { "w:rPr": [] },
+                ],
+            });
+        });
     });
 
     describe("formatting methods: run properties", () => {

--- a/src/file/styles/style/paragraph-style.ts
+++ b/src/file/styles/style/paragraph-style.ts
@@ -7,6 +7,7 @@ import {
     KeepNext,
     LeftTabStop,
     MaxRightTabStop,
+    OutlineLevel,
     ParagraphProperties,
     Spacing,
     ThematicBreak,
@@ -31,6 +32,11 @@ export class ParagraphStyle extends Style {
 
     public addParagraphProperty(property: XmlComponent): ParagraphStyle {
         this.paragraphProperties.push(property);
+        return this;
+    }
+
+    public outlineLevel(level: string): ParagraphStyle {
+        this.paragraphProperties.push(new OutlineLevel(level));
         return this;
     }
 


### PR DESCRIPTION
In order to manually add a paragraph into the TOC you can specify outline level in paragraph properties (as already discussed on #248).

It can be useful to specify this property also into the paragraph style, so that all paragraphs using that style will go into the TOC.

_Example_

`this.doc.Styles.createParagraphStyle('myStyleThatGoesInTOC').outlineLevel('1');`