### PR TITLE
Add bold and italics to character style + customize hyperlink

### DIFF
--- a/src/file/paragraph/links/hyperlink.ts
+++ b/src/file/paragraph/links/hyperlink.ts
@@ -5,6 +5,7 @@ import { HyperlinkAttributes, IHyperlinkAttributesProperties } from "./hyperlink
 
 export class Hyperlink extends XmlComponent {
     public readonly linkId: number;
+    private readonly textRun: TextRun;
 
     constructor(text: string, relationshipsCount: number, anchor?: string) {
         super("w:hyperlink");
@@ -19,6 +20,11 @@ export class Hyperlink extends XmlComponent {
 
         const attributes = new HyperlinkAttributes(props);
         this.root.push(attributes);
-        this.root.push(new TextRun(text).style("Hyperlink"));
+        this.textRun = new TextRun(text).style("Hyperlink");
+        this.root.push(this.textRun);
+    }
+
+    public get TextRun(): TextRun {
+        return this.textRun;
     }
 }

--- a/src/file/styles/style/character-style.spec.ts
+++ b/src/file/styles/style/character-style.spec.ts
@@ -243,6 +243,56 @@ describe("CharacterStyle", () => {
             });
         });
 
+        it("#bold", () => {
+            const style = new CharacterStyle("myStyleId").bold();
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "character", "w:styleId": "myStyleId" } },
+                    {
+                        "w:rPr": [{ "w:b": [{ _attr: { "w:val": true } }] }],
+                    },
+                    {
+                        "w:uiPriority": [
+                            {
+                                _attr: {
+                                    "w:val": "99",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "w:unhideWhenUsed": [],
+                    },
+                ],
+            });
+        });
+
+        it("#italics", () => {
+            const style = new CharacterStyle("myStyleId").italics();
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "character", "w:styleId": "myStyleId" } },
+                    {
+                        "w:rPr": [{ "w:i": [{ _attr: { "w:val": true } }] }],
+                    },
+                    {
+                        "w:uiPriority": [
+                            {
+                                _attr: {
+                                    "w:val": "99",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "w:unhideWhenUsed": [],
+                    },
+                ],
+            });
+        });
+
         it("#link", () => {
             const style = new CharacterStyle("myStyleId").link("MyLink");
             const tree = new Formatter().format(style);

--- a/src/file/styles/style/character-style.ts
+++ b/src/file/styles/style/character-style.ts
@@ -29,6 +29,14 @@ export class CharacterStyle extends Style {
         return this.addRunProperty(new formatting.Color(color));
     }
 
+    public bold(): CharacterStyle {
+        return this.addRunProperty(new formatting.Bold());
+    }
+
+    public italics(): CharacterStyle {
+        return this.addRunProperty(new formatting.Italics());
+    }
+
     public underline(underlineType?: string, color?: string): CharacterStyle {
         return this.addRunProperty(new formatting.Underline(underlineType, color));
     }


### PR DESCRIPTION
**Add bold and italics to character style**
Character style now has bold and italics.

_Example_

`this.doc.Styles.createCharacterStyle('myStyle').bold().italics();`

**Customize hyperlink**
Since hyperlinks are made of textRun, it should be useful to let public access to that textRun in order to customize the style of an hyperlink.
That should close #194.

_Example_

`let hyperlink = this.doc.createHyperlink('url', 'this is a link');
hyperlink.TextRun.bold().color('2266ff');`