### PR TITLE
Fix: settings are ignored by Word without relationship and content type

### DIFF
--- a/src/file/content-types/content-types.spec.ts
+++ b/src/file/content-types/content-types.spec.ts
@@ -79,6 +79,26 @@ describe("ContentTypes", () => {
                     },
                 ],
             });
+            expect(tree["Types"][13]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml",
+                            PartName: "/word/footnotes.xml",
+                        },
+                    },
+                ],
+            });
+            expect(tree["Types"][14]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml",
+                            PartName: "/word/settings.xml",
+                        },
+                    },
+                ],
+            });
         });
     });
 
@@ -88,7 +108,7 @@ describe("ContentTypes", () => {
             contentTypes.addFooter(102);
             const tree = new Formatter().format(contentTypes);
 
-            expect(tree["Types"][14]).to.deep.equal({
+            expect(tree["Types"][15]).to.deep.equal({
                 Override: [
                     {
                         _attr: {
@@ -99,7 +119,7 @@ describe("ContentTypes", () => {
                 ],
             });
 
-            expect(tree["Types"][15]).to.deep.equal({
+            expect(tree["Types"][16]).to.deep.equal({
                 Override: [
                     {
                         _attr: {
@@ -118,7 +138,7 @@ describe("ContentTypes", () => {
             contentTypes.addHeader(202);
             const tree = new Formatter().format(contentTypes);
 
-            expect(tree["Types"][14]).to.deep.equal({
+            expect(tree["Types"][15]).to.deep.equal({
                 Override: [
                     {
                         _attr: {
@@ -129,7 +149,7 @@ describe("ContentTypes", () => {
                 ],
             });
 
-            expect(tree["Types"][15]).to.deep.equal({
+            expect(tree["Types"][16]).to.deep.equal({
                 Override: [
                     {
                         _attr: {

--- a/src/file/content-types/content-types.ts
+++ b/src/file/content-types/content-types.ts
@@ -30,6 +30,7 @@ export class ContentTypes extends XmlComponent {
         this.root.push(new Override("application/vnd.openxmlformats-officedocument.extended-properties+xml", "/docProps/app.xml"));
         this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml", "/word/numbering.xml"));
         this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml", "/word/footnotes.xml"));
+        this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml", "/word/settings.xml"));
     }
 
     public addFooter(index: number): void {

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -324,6 +324,11 @@ export class File {
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes",
             "footnotes.xml",
         );
+        this.docRelationships.createRelationship(
+            this.currentRelationshipId++,
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings",
+            "settings.xml",
+        );
     }
 
     private groupHeaders(headers: IDocumentHeader[], group: IHeaderFooterGroup<HeaderWrapper> = {}): IHeaderFooterGroup<HeaderWrapper> {


### PR DESCRIPTION
After adding some settings to _settings.xml_ file, we realized that Word was ignoring those settings. After some research it came out that Word needs also that the settings relationship and content type are specified.

More precisely: in _document.xml.rels_ the relationship missing was:
`<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"></Relationship>`

While in _[Content_Types].xml_ the content type missing was:
`<Override ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml" PartName="/word/settings.xml"></Override>`
