### PR TITLE
Add setting for not justify lines ending in soft line break

### DIFF
--- a/src/file/settings/compatibility.spec.ts
+++ b/src/file/settings/compatibility.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import { Formatter } from "export/formatter";
+import { Compatibility } from "file/settings/compatibility";
+
+describe("Compatibility", () => {
+    describe("#constructor", () => {
+        it("creates an initially empty property object", () => {
+            const compatibility = new Compatibility();
+
+            const tree = new Formatter().format(compatibility);
+            expect(tree).to.deep.equal({ "w:compat": [] });
+        });
+    });
+
+    describe("#doNotExpandShiftReturn", () => {
+        it("should create a setting for not justifying lines ending in soft line break", () => {
+            const compatibility = new Compatibility();
+            compatibility.doNotExpandShiftReturn();
+
+            const tree = new Formatter().format(compatibility);
+            expect(tree).to.deep.equal({ "w:compat": [{ "w:doNotExpandShiftReturn": [] }] });
+        });
+    });
+});

--- a/src/file/settings/compatibility.ts
+++ b/src/file/settings/compatibility.ts
@@ -1,0 +1,19 @@
+import { XmlComponent } from "file/xml-components";
+
+class DoNotExpandShiftReturn extends XmlComponent {
+    constructor() {
+        super("w:doNotExpandShiftReturn");
+    }
+}
+
+export class Compatibility extends XmlComponent {
+    constructor() {
+        super("w:compat");
+    }
+
+    public doNotExpandShiftReturn(): Compatibility {
+        this.root.push(new DoNotExpandShiftReturn());
+
+        return this;
+    }
+}

--- a/src/file/settings/settings.spec.ts
+++ b/src/file/settings/settings.spec.ts
@@ -60,4 +60,25 @@ describe("Settings", () => {
             assertSettingsWithUpdateFields(settings);
         });
     });
+    describe("#addCompatibility", () => {
+        it("should add an empty Compatibility", () => {
+            const settings = new Settings();
+            settings.addCompatibility();
+
+            const tree = new Formatter().format(settings);
+            let keys: string[] = Object.keys(tree);
+            expect(keys[0]).to.be.equal("w:settings");
+            const rootArray = tree["w:settings"];
+            expect(rootArray).is.an.instanceof(Array);
+            expect(rootArray).has.length(2);
+            keys = Object.keys(rootArray[0]);
+            expect(keys).is.an.instanceof(Array);
+            expect(keys).has.length(1);
+            expect(keys[0]).to.be.equal("_attr");
+            keys = Object.keys(rootArray[1]);
+            expect(keys).is.an.instanceof(Array);
+            expect(keys).has.length(1);
+            expect(keys[0]).to.be.equal("w:compat");
+        });
+    });
 });

--- a/src/file/settings/settings.ts
+++ b/src/file/settings/settings.ts
@@ -1,5 +1,7 @@
 import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
+import { Compatibility } from "./compatibility";
 import { UpdateFields } from "./update-fields";
+
 export interface ISettingsAttributesProperties {
     readonly wpc?: string;
     readonly mc?: string;
@@ -19,6 +21,7 @@ export interface ISettingsAttributesProperties {
     readonly wps?: string;
     readonly Ignorable?: string;
 }
+
 export class SettingsAttributes extends XmlAttributeComponent<ISettingsAttributesProperties> {
     protected readonly xmlKeys = {
         wpc: "xmlns:wpc",
@@ -40,7 +43,10 @@ export class SettingsAttributes extends XmlAttributeComponent<ISettingsAttribute
         Ignorable: "mc:Ignorable",
     };
 }
+
 export class Settings extends XmlComponent {
+    private readonly compatibility;
+
     constructor() {
         super("w:settings");
         this.root.push(
@@ -64,10 +70,20 @@ export class Settings extends XmlComponent {
                 Ignorable: "w14 w15 wp14",
             }),
         );
+        this.compatibility = new Compatibility();
     }
+
     public addUpdateFields(): void {
         if (!this.root.find((child) => child instanceof UpdateFields)) {
             this.addChildElement(new UpdateFields());
         }
+    }
+
+    public addCompatibility(): Compatibility {
+        if (!this.root.find((child) => child instanceof Compatibility)) {
+            this.addChildElement(this.compatibility);
+        }
+
+        return this.compatibility;
     }
 }


### PR DESCRIPTION
Add a setting to do not justify the contents of incomplete lines, which end in a soft line break, when the parent paragraph is fully justified. Works in LibreOffice and Word.

Steps to reproduce this In Word 2013:
- Click the File tab, Options, Advanced.
- Go to absolute bottom of the Advanced options, and click to expand Layout Options.
- Tick “Don’t expand character spaces on a line that ends with SHIFT-RETURN“

**Before**
![before](https://user-images.githubusercontent.com/7989576/53820338-e060c680-3f6b-11e9-817c-ecb43271951e.png)

**After**
![after](https://user-images.githubusercontent.com/7989576/53820344-e2c32080-3f6b-11e9-9afe-24a2ed6e0d78.png)

_Example_

`this.doc.Settings.addCompatibility().doNotExpandShiftReturn()`
