### PR TITLE
Fix: table width in percentage should include '%'

### DIFF
--- a/src/file/table/table-properties/table-width.ts
+++ b/src/file/table/table-properties/table-width.ts
@@ -15,6 +15,7 @@ class TableWidthAttributes extends XmlAttributeComponent<ITableWidth> {
 export class PreferredTableWidth extends XmlComponent {
     constructor(type: WidthType, w: number) {
         super("w:tblW");
-        this.root.push(new TableWidthAttributes({ type, w }));
+        const width: number | string = type === WidthType.PERCENTAGE ? `${w}%` : w;
+        this.root.push(new TableWidthAttributes({ type: type, w: width }));
     }
 }

--- a/src/file/table/table.spec.ts
+++ b/src/file/table/table.spec.ts
@@ -200,7 +200,7 @@ describe("Table", () => {
                 .which.is.an("array")
                 .with.has.length.at.least(1);
             expect(tree["w:tbl"][0]).to.deep.equal({
-                "w:tblPr": [DEFAULT_TABLE_PROPERTIES, { "w:tblW": [{ _attr: { "w:type": "pct", "w:w": 1000 } }] }],
+                "w:tblPr": [DEFAULT_TABLE_PROPERTIES, { "w:tblW": [{ _attr: { "w:type": "pct", "w:w": "1000%" } }] }],
             });
         });
 


### PR DESCRIPTION
Hi! 
Trying the last version I found out that table with width in percentage didn't work anymore.
It seems that from 2011 version of the standard OOXML when type="pct" you have to include % (more info [here](http://officeopenxml.com/WPtableWidth.php)).
I tried with both Office 2019 and LibreOffice last version.

I opened a PR instead of an issue. If you prefer you can fix it in other ways and just discard this.
Thanks