### PR TITLE
Fix: duplicated generation of last section properties

### DIFF
--- a/src/file/document/body/body.ts
+++ b/src/file/document/body/body.ts
@@ -37,7 +37,7 @@ export class Body extends XmlComponent {
     }
     public prepForXml(): IXmlableObject | undefined {
         if (this.sections.length === 1) {
-            this.root.push(this.sections[0]);
+            this.root.push(this.sections.pop() as SectionProperties);
         }
 
         return super.prepForXml();


### PR DESCRIPTION
When generating XML for body, section properties for last section are duplicated (see #259).
It seems that you have to empty sections array after adding last section to body (don't know why the formatter is passing two times there).

This solves the problems of 

- duplicated header/footer of last section in LibreOffice - Fixes #259 
- wrong header/footer of last section in Word