### PR TITLE
Fix table cell margin type XML attribute

### DIFF
--- a/src/file/table/table-properties/table-cell-margin.spec.ts
+++ b/src/file/table/table-properties/table-cell-margin.spec.ts
@@ -18,7 +18,7 @@ describe("TableCellMargin", () => {
             const cellMargain = new TableCellMargin();
             cellMargain.addTopMargin(1234, WidthType.DXA);
             const tree = new Formatter().format(cellMargain);
-            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:top": [{ _attr: { "w:sz": "dxa", "w:w": 1234 } }] }] });
+            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:top": [{ _attr: { "w:type": "dxa", "w:w": 1234 } }] }] });
         });
     });
 
@@ -27,7 +27,7 @@ describe("TableCellMargin", () => {
             const cellMargain = new TableCellMargin();
             cellMargain.addLeftMargin(1234, WidthType.DXA);
             const tree = new Formatter().format(cellMargain);
-            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:left": [{ _attr: { "w:sz": "dxa", "w:w": 1234 } }] }] });
+            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:left": [{ _attr: { "w:type": "dxa", "w:w": 1234 } }] }] });
         });
     });
 
@@ -36,7 +36,7 @@ describe("TableCellMargin", () => {
             const cellMargain = new TableCellMargin();
             cellMargain.addBottomMargin(1234, WidthType.DXA);
             const tree = new Formatter().format(cellMargain);
-            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:bottom": [{ _attr: { "w:sz": "dxa", "w:w": 1234 } }] }] });
+            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:bottom": [{ _attr: { "w:type": "dxa", "w:w": 1234 } }] }] });
         });
     });
 
@@ -45,7 +45,7 @@ describe("TableCellMargin", () => {
             const cellMargain = new TableCellMargin();
             cellMargain.addRightMargin(1234, WidthType.DXA);
             const tree = new Formatter().format(cellMargain);
-            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:right": [{ _attr: { "w:sz": "dxa", "w:w": 1234 } }] }] });
+            expect(tree).to.deep.equal({ "w:tblCellMar": [{ "w:right": [{ _attr: { "w:type": "dxa", "w:w": 1234 } }] }] });
         });
     });
 });

--- a/src/file/table/table-properties/table-cell-margin.ts
+++ b/src/file/table/table-properties/table-cell-margin.ts
@@ -3,7 +3,7 @@ import { IXmlableObject, XmlAttributeComponent, XmlComponent } from "file/xml-co
 import { WidthType } from "../table-cell";
 
 class TableCellMarginAttributes extends XmlAttributeComponent<{ readonly type: WidthType; readonly value: number }> {
-    protected readonly xmlKeys = { value: "w:w", type: "w:sz" };
+    protected readonly xmlKeys = { value: "w:w", type: "w:type" };
 }
 
 class BaseTableCellMargin extends XmlComponent {

--- a/src/file/table/table-properties/table-properties.spec.ts
+++ b/src/file/table/table-properties/table-properties.spec.ts
@@ -48,7 +48,7 @@ describe("TableProperties", () => {
             tp.CellMargin.addTopMargin(1234, WidthType.DXA);
             const tree = new Formatter().format(tp);
             expect(tree).to.deep.equal({
-                "w:tblPr": [{ "w:tblCellMar": [{ "w:top": [{ _attr: { "w:sz": "dxa", "w:w": 1234 } }] }] }],
+                "w:tblPr": [{ "w:tblCellMar": [{ "w:top": [{ _attr: { "w:type": "dxa", "w:w": 1234 } }] }] }],
             });
         });
 
@@ -57,7 +57,7 @@ describe("TableProperties", () => {
             tp.CellMargin.addLeftMargin(1234, WidthType.DXA);
             const tree = new Formatter().format(tp);
             expect(tree).to.deep.equal({
-                "w:tblPr": [{ "w:tblCellMar": [{ "w:left": [{ _attr: { "w:sz": "dxa", "w:w": 1234 } }] }] }],
+                "w:tblPr": [{ "w:tblCellMar": [{ "w:left": [{ _attr: { "w:type": "dxa", "w:w": 1234 } }] }] }],
             });
         });
     });

--- a/src/file/table/table.spec.ts
+++ b/src/file/table/table.spec.ts
@@ -14,7 +14,7 @@ const DEFAULT_TABLE_PROPERTIES = {
             "w:bottom": [
                 {
                     _attr: {
-                        "w:sz": "auto",
+                        "w:type": "auto",
                         "w:w": 0,
                     },
                 },
@@ -24,7 +24,7 @@ const DEFAULT_TABLE_PROPERTIES = {
             "w:top": [
                 {
                     _attr: {
-                        "w:sz": "auto",
+                        "w:type": "auto",
                         "w:w": 0,
                     },
                 },
@@ -34,7 +34,7 @@ const DEFAULT_TABLE_PROPERTIES = {
             "w:left": [
                 {
                     _attr: {
-                        "w:sz": "auto",
+                        "w:type": "auto",
                         "w:w": 0,
                     },
                 },
@@ -44,7 +44,7 @@ const DEFAULT_TABLE_PROPERTIES = {
             "w:right": [
                 {
                     _attr: {
-                        "w:sz": "auto",
+                        "w:type": "auto",
                         "w:w": 0,
                     },
                 },
@@ -81,10 +81,10 @@ const WIDTHS = {
 //             "w:tblPr": [
 //                 {
 //                     "w:tblCellMar": [
-//                         { "w:bottom": [{ _attr: { "w:sz": "auto", "w:w": 0 } }] },
-//                         { "w:top": [{ _attr: { "w:sz": "auto", "w:w": 0 } }] },
-//                         { "w:left": [{ _attr: { "w:sz": "auto", "w:w": 0 } }] },
-//                         { "w:right": [{ _attr: { "w:sz": "auto", "w:w": 0 } }] },
+//                         { "w:bottom": [{ _attr: { "w:type": "auto", "w:w": 0 } }] },
+//                         { "w:top": [{ _attr: { "w:type": "auto", "w:w": 0 } }] },
+//                         { "w:left": [{ _attr: { "w:type": "auto", "w:w": 0 } }] },
+//                         { "w:right": [{ _attr: { "w:type": "auto", "w:w": 0 } }] },
 //                     ],
 //                 },
 //                 {


### PR DESCRIPTION
Change table cell margin type attribute form w:sz to w:type as per http://officeopenxml.com/WPtableCellMargins.php

Fixes #303