### PR TITLE
Add table row height

### DIFF
--- a/src/file/table/index.ts
+++ b/src/file/table/index.ts
@@ -2,3 +2,4 @@ export * from "./table";
 export * from "./table-cell";
 export * from "./table-properties";
 export * from "./shading";
+export * from "./table-row";

--- a/src/file/table/table-row/index.ts
+++ b/src/file/table/table-row/index.ts
@@ -1,2 +1,3 @@
 export * from "./table-row";
 export * from "./table-row-properties";
+export * from "./table-row-height";

--- a/src/file/table/table-row/table-row-height.ts
+++ b/src/file/table/table-row/table-row-height.ts
@@ -1,0 +1,32 @@
+import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
+
+export enum HeightRule {
+    /** Height is determined based on the content, so value is ignored. */
+    AUTO = "auto",
+    /** At least the value specified */
+    ATLEAST = "atLeast",
+    /** Exactly the value specified */
+    EXACT = "exact",
+}
+
+interface ITableRowHeight {
+    readonly height: number;
+    readonly rule: HeightRule;
+}
+
+export class TableRowHeightAttributes extends XmlAttributeComponent<ITableRowHeight> {
+    protected readonly xmlKeys = { height: "w:val", rule: "w:hRule" };
+}
+
+export class TableRowHeight extends XmlComponent {
+    constructor(value: number, rule: HeightRule) {
+        super("w:trHeight");
+
+        this.root.push(
+            new TableRowHeightAttributes({
+                height: value,
+                rule: rule,
+            }),
+        );
+    }
+}

--- a/src/file/table/table-row/table-row-properties.spec.ts
+++ b/src/file/table/table-row/table-row-properties.spec.ts
@@ -34,25 +34,19 @@ describe("TableRowProperties", () => {
     });
 
     describe("#setHeight", () => {
-        it("sets exact row height", () => {
+        it("sets row height exact", () => {
             const rowProperties = new TableRowProperties();
             rowProperties.setHeight(100, HeightRule.EXACT);
             const tree = new Formatter().format(rowProperties);
             expect(tree).to.deep.equal({ "w:trPr": [{ "w:trHeight": { _attr: { "w:val": 100, "w:hRule": "exact" } } }] });
         });
-    });
-
-    describe("#setHeight", () => {
-        it("sets auto row height", () => {
+        it("sets row height auto", () => {
             const rowProperties = new TableRowProperties();
             rowProperties.setHeight(100, HeightRule.AUTO);
             const tree = new Formatter().format(rowProperties);
             expect(tree).to.deep.equal({ "w:trPr": [{ "w:trHeight": { _attr: { "w:val": 100, "w:hRule": "auto" } } }] });
         });
-    });
-
-    describe("#setHeight", () => {
-        it("sets at least row height", () => {
+        it("sets row height at least", () => {
             const rowProperties = new TableRowProperties();
             rowProperties.setHeight(100, HeightRule.ATLEAST);
             const tree = new Formatter().format(rowProperties);

--- a/src/file/table/table-row/table-row-properties.spec.ts
+++ b/src/file/table/table-row/table-row-properties.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { Formatter } from "export/formatter";
+import { HeightRule } from "file/table/table-row/table-row-height";
 import { TableRowProperties } from "./table-row-properties";
 
 describe("TableRowProperties", () => {
@@ -29,6 +30,33 @@ describe("TableRowProperties", () => {
             rowProperties.setTableHeader();
             const tree = new Formatter().format(rowProperties);
             expect(tree).to.deep.equal({ "w:trPr": [{ "w:tblHeader": { _attr: { "w:val": true } } }] });
+        });
+    });
+
+    describe("#setHeight", () => {
+        it("sets exact row height", () => {
+            const rowProperties = new TableRowProperties();
+            rowProperties.setHeight(100, HeightRule.EXACT);
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({ "w:trPr": [{ "w:trHeight": { _attr: { "w:val": 100, "w:hRule": "exact" } } }] });
+        });
+    });
+
+    describe("#setHeight", () => {
+        it("sets auto row height", () => {
+            const rowProperties = new TableRowProperties();
+            rowProperties.setHeight(100, HeightRule.AUTO);
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({ "w:trPr": [{ "w:trHeight": { _attr: { "w:val": 100, "w:hRule": "auto" } } }] });
+        });
+    });
+
+    describe("#setHeight", () => {
+        it("sets at least row height", () => {
+            const rowProperties = new TableRowProperties();
+            rowProperties.setHeight(100, HeightRule.ATLEAST);
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({ "w:trPr": [{ "w:trHeight": { _attr: { "w:val": 100, "w:hRule": "atLeast" } } }] });
         });
     });
 });

--- a/src/file/table/table-row/table-row-properties.ts
+++ b/src/file/table/table-row/table-row-properties.ts
@@ -1,3 +1,4 @@
+import { HeightRule, TableRowHeight } from "file/table/table-row/table-row-height";
 import { IgnoreIfEmptyXmlComponent, XmlAttributeComponent, XmlComponent } from "file/xml-components";
 
 export class TableRowProperties extends IgnoreIfEmptyXmlComponent {
@@ -13,6 +14,12 @@ export class TableRowProperties extends IgnoreIfEmptyXmlComponent {
 
     public setTableHeader(): TableRowProperties {
         this.root.push(new TableHeader());
+
+        return this;
+    }
+
+    public setHeight(height: number, rule: HeightRule): TableRowProperties {
+        this.root.push(new TableRowHeight(height, rule));
 
         return this;
     }

--- a/src/file/table/table-row/table-row.spec.ts
+++ b/src/file/table/table-row/table-row.spec.ts
@@ -2,10 +2,10 @@ import { expect } from "chai";
 
 import { Formatter } from "export/formatter";
 
+import { HeightRule } from "file/table/table-row/table-row-height";
+import { EMPTY_OBJECT } from "file/xml-components";
 import { TableCell } from "../table-cell";
 import { TableRow } from "./table-row";
-
-import { EMPTY_OBJECT } from "file/xml-components";
 
 describe("TableRow", () => {
     describe("#constructor", () => {
@@ -65,6 +65,30 @@ describe("TableRow", () => {
 
             tableRow.mergeCells(0, 1);
             expect(() => tableRow.getCell(1)).to.throw();
+        });
+    });
+
+    describe("#setHeight", () => {
+        it("should set row height", () => {
+            const tableRow = new TableRow([]);
+            tableRow.setHeight(100, HeightRule.EXACT);
+            const tree = new Formatter().format(tableRow);
+            expect(tree).to.deep.equal({
+                "w:tr": [
+                    {
+                        "w:trPr": [
+                            {
+                                "w:trHeight": {
+                                    _attr: {
+                                        "w:hRule": "exact",
+                                        "w:val": 100,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
         });
     });
 });

--- a/src/file/table/table-row/table-row.ts
+++ b/src/file/table/table-row/table-row.ts
@@ -1,5 +1,5 @@
+import { HeightRule } from "file/table/table-row/table-row-height";
 import { XmlComponent } from "file/xml-components";
-
 import { TableCell } from "../table-cell";
 import { TableRowProperties } from "./table-row-properties";
 
@@ -46,6 +46,12 @@ export class TableRow extends XmlComponent {
 
     public setTableHeader(): TableRow {
         this.properties.setTableHeader();
+
+        return this;
+    }
+
+    public setHeight(height: number, rule: HeightRule): TableRow {
+        this.properties.setHeight(height, rule);
 
         return this;
     }


### PR DESCRIPTION
Add table row height:

`row.setHeight(value, rule)`

- value: Specifies the row's height, in twentieths of a point.
- rule: Specifies the meaning of the height. Can be:
  HeightRule.AUTO (Height is determined based on the content, so value is ignored)
  HeightRule.ATLEAST (At least the value specified)
  HeightRule.EXACT (Exactly the value specified)

Closes #302 