### PR TITLE
Fix: add missing exports

### DIFF
--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -9,3 +9,5 @@ export * from "./document";
 export * from "./styles";
 export * from "./table-of-contents";
 export * from "./xml-components";
+export * from "./header-wrapper";
+export * from "./footer-wrapper";

--- a/src/file/styles/index.ts
+++ b/src/file/styles/index.ts
@@ -1,1 +1,3 @@
 export * from "./styles";
+export * from "./style/character-style";
+export * from "./style/paragraph-style";


### PR DESCRIPTION
CharacterStyle, ParagraphStyle,  HeaderWrapper and FooterWrapper were not exported.
It would be useful to export them, thanks!