### PR TITLE
Make prettified XML a Packer-wide configurable option

### DIFF
--- a/src/export/packer/next-compiler.ts
+++ b/src/export/packer/next-compiler.ts
@@ -30,10 +30,12 @@ interface IXmlifyedFileMapping {
 export class Compiler {
     private readonly formatter: Formatter;
     private readonly imageReplacer: ImageReplacer;
+    private readonly prettifyXml?: boolean;
 
-    constructor() {
+    constructor(prettifyXml?: boolean) {
         this.formatter = new Formatter();
         this.imageReplacer = new ImageReplacer();
+        this.prettifyXml = prettifyXml;
     }
 
     public compile(file: File): JSZip {
@@ -71,7 +73,7 @@ export class Compiler {
         return {
             Relationships: {
                 data: (() => {
-                    const xmlData = xml(this.formatter.format(file.Document));
+                    const xmlData = xml(this.formatter.format(file.Document), this.prettifyXml);
                     const mediaDatas = this.imageReplacer.getMediaData(xmlData, file.Media);
 
                     mediaDatas.forEach((mediaData, i) => {
@@ -82,13 +84,13 @@ export class Compiler {
                         );
                     });
 
-                    return xml(this.formatter.format(file.DocumentRelationships));
+                    return xml(this.formatter.format(file.DocumentRelationships), this.prettifyXml);
                 })(),
                 path: "word/_rels/document.xml.rels",
             },
             Document: {
                 data: (() => {
-                    const tempXmlData = xml(this.formatter.format(file.Document), true);
+                    const tempXmlData = xml(this.formatter.format(file.Document), this.prettifyXml);
                     const mediaDatas = this.imageReplacer.getMediaData(tempXmlData, file.Media);
                     const xmlData = this.imageReplacer.replace(tempXmlData, mediaDatas, documentRelationshipCount);
 
@@ -97,7 +99,7 @@ export class Compiler {
                 path: "word/document.xml",
             },
             Styles: {
-                data: xml(this.formatter.format(file.Styles)),
+                data: xml(this.formatter.format(file.Styles), this.prettifyXml),
                 path: "word/styles.xml",
             },
             Properties: {
@@ -110,15 +112,15 @@ export class Compiler {
                 path: "docProps/core.xml",
             },
             Numbering: {
-                data: xml(this.formatter.format(file.Numbering)),
+                data: xml(this.formatter.format(file.Numbering), this.prettifyXml),
                 path: "word/numbering.xml",
             },
             FileRelationships: {
-                data: xml(this.formatter.format(file.FileRelationships)),
+                data: xml(this.formatter.format(file.FileRelationships), this.prettifyXml),
                 path: "_rels/.rels",
             },
             HeaderRelationships: file.Headers.map((headerWrapper, index) => {
-                const xmlData = xml(this.formatter.format(headerWrapper.Header));
+                const xmlData = xml(this.formatter.format(headerWrapper.Header), this.prettifyXml);
                 const mediaDatas = this.imageReplacer.getMediaData(xmlData, file.Media);
 
                 mediaDatas.forEach((mediaData, i) => {
@@ -130,12 +132,12 @@ export class Compiler {
                 });
 
                 return {
-                    data: xml(this.formatter.format(headerWrapper.Relationships)),
+                    data: xml(this.formatter.format(headerWrapper.Relationships), this.prettifyXml),
                     path: `word/_rels/header${index + 1}.xml.rels`,
                 };
             }),
             FooterRelationships: file.Footers.map((footerWrapper, index) => {
-                const xmlData = xml(this.formatter.format(footerWrapper.Footer));
+                const xmlData = xml(this.formatter.format(footerWrapper.Footer), this.prettifyXml);
                 const mediaDatas = this.imageReplacer.getMediaData(xmlData, file.Media);
 
                 mediaDatas.forEach((mediaData, i) => {
@@ -147,12 +149,12 @@ export class Compiler {
                 });
 
                 return {
-                    data: xml(this.formatter.format(footerWrapper.Relationships)),
+                    data: xml(this.formatter.format(footerWrapper.Relationships), this.prettifyXml),
                     path: `word/_rels/footer${index + 1}.xml.rels`,
                 };
             }),
             Headers: file.Headers.map((headerWrapper, index) => {
-                const tempXmlData = xml(this.formatter.format(headerWrapper.Header));
+                const tempXmlData = xml(this.formatter.format(headerWrapper.Header), this.prettifyXml);
                 const mediaDatas = this.imageReplacer.getMediaData(tempXmlData, file.Media);
                 // TODO: 0 needs to be changed when headers get relationships of their own
                 const xmlData = this.imageReplacer.replace(tempXmlData, mediaDatas, 0);
@@ -163,7 +165,7 @@ export class Compiler {
                 };
             }),
             Footers: file.Footers.map((footerWrapper, index) => {
-                const tempXmlData = xml(this.formatter.format(footerWrapper.Footer));
+                const tempXmlData = xml(this.formatter.format(footerWrapper.Footer), this.prettifyXml);
                 const mediaDatas = this.imageReplacer.getMediaData(tempXmlData, file.Media);
                 // TODO: 0 needs to be changed when headers get relationships of their own
                 const xmlData = this.imageReplacer.replace(tempXmlData, mediaDatas, 0);
@@ -174,19 +176,19 @@ export class Compiler {
                 };
             }),
             ContentTypes: {
-                data: xml(this.formatter.format(file.ContentTypes)),
+                data: xml(this.formatter.format(file.ContentTypes), this.prettifyXml),
                 path: "[Content_Types].xml",
             },
             AppProperties: {
-                data: xml(this.formatter.format(file.AppProperties)),
+                data: xml(this.formatter.format(file.AppProperties), this.prettifyXml),
                 path: "docProps/app.xml",
             },
             FootNotes: {
-                data: xml(this.formatter.format(file.FootNotes)),
+                data: xml(this.formatter.format(file.FootNotes), this.prettifyXml),
                 path: "word/footnotes.xml",
             },
             Settings: {
-                data: xml(this.formatter.format(file.Settings)),
+                data: xml(this.formatter.format(file.Settings), this.prettifyXml),
                 path: "word/settings.xml",
             },
         };

--- a/src/export/packer/packer.ts
+++ b/src/export/packer/packer.ts
@@ -4,8 +4,8 @@ import { Compiler } from "./next-compiler";
 export class Packer {
     private readonly compiler: Compiler;
 
-    constructor() {
-        this.compiler = new Compiler();
+    constructor(prettifyXml?: boolean) {
+        this.compiler = new Compiler(prettifyXml);
     }
 
     public async toBuffer(file: File): Promise<Buffer> {


### PR DESCRIPTION
The xml library's `xml()` function was being passed a flag for pretty printing the XML in `word/document.xml`. This was causing some parsers (not Word itself) to break when they didn't expect whitepsace. It was also causing some files to be prettified and others to be ugly.

This ensures consistent prettification (and default non-whitespace XML) by taking an optional parameter at `Packer()` instantiation time that defaults to false and tells the compiler whether to compile in pretty (true) or ugly (false) XML.