### PR TITLE
Add Highlight and Shading to the properties

### DIFF
--- a/demo/demo45.ts
+++ b/demo/demo45.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import { Document, Packer, Paragraph, TextRun } from "../build";
+
+const doc = new Document();
+
+const header = doc.Header.createTable(1, 3)
+  // @ts-ignore
+  header.properties.root[1] = []
+
+   header.getCell(0, 2).addParagraph(
+    new Paragraph()
+      .addRun(
+        new TextRun('W.P. 660')
+          .color('red')
+          .bold()
+          .size(12 * 2)
+          .font('Garamond')
+          .highlight('yellow')
+      )
+      .right()
+  )
+
+const packer = new Packer();
+
+packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});

--- a/demo/demo46.ts
+++ b/demo/demo46.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import { Document, Packer, Paragraph, TextRun } from "../build";
+
+const doc = new Document();
+
+const header = doc.Header.createTable(1, 3)
+  // @ts-ignore
+  header.properties.root[1] = []
+
+   header.getCell(0, 2).addParagraph(
+    new Paragraph()
+      .addRun(
+        new TextRun('W.P. 660')
+          .color('red')
+          .bold()
+          .size(12 * 2)
+          .font('Garamond')
+          .shadow('pct10','00FFFF','FF0000')
+      )
+      .right()
+  )
+
+const packer = new Packer();
+
+packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});

--- a/src/file/numbering/level.ts
+++ b/src/file/numbering/level.ts
@@ -198,6 +198,15 @@ export class LevelBase extends XmlComponent {
         return this;
     }
 
+    public highlight(color: string): Level {
+        this.addRunProperty(new formatting.Highlight(color));
+        return this;
+    }
+
+    public shadow(value: string, fill: string, color: string): Level {
+        this.addRunProperty(new formatting.Shadow(value, fill, color));
+        return this;
+    }
     // --------------------- Paragraph formatting ------------------------ //
 
     public center(): Level {

--- a/src/file/numbering/numbering.spec.ts
+++ b/src/file/numbering/numbering.spec.ts
@@ -330,7 +330,7 @@ describe("AbstractNumbering", () => {
                 const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.").highlight("005599");
                 const tree = new Formatter().format(level);
                 expect(tree["w:lvl"]).to.include({
-                    "w:rPr": [{ "w:highlight ": { _attr: { "w:val": "005599" } } }],
+                    "w:rPr": [{ "w:highlight": { _attr: { "w:val": "005599" } } }],
                 });
             });
 
@@ -339,7 +339,7 @@ describe("AbstractNumbering", () => {
                 const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.").shadow("pct10", "00FFFF", "FF0000");
                 const tree = new Formatter().format(level);
                 expect(tree["w:lvl"]).to.include({
-                    "w:rPr": [{ "w:shd ": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
+                    "w:rPr": [{ "w:shd": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
                 });
             });
 

--- a/src/file/numbering/numbering.spec.ts
+++ b/src/file/numbering/numbering.spec.ts
@@ -325,6 +325,24 @@ describe("AbstractNumbering", () => {
                 });
             });
 
+            it("#highlight", () => {
+                const abstractNumbering = new AbstractNumbering(1);
+                const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.").highlight("005599");
+                const tree = new Formatter().format(level);
+                expect(tree["w:lvl"]).to.include({
+                    "w:rPr": [{ "w:highlight ": { _attr: { "w:val": "005599" } } }],
+                });
+            });
+
+            it("#shadow", () => {
+                const abstractNumbering = new AbstractNumbering(1);
+                const level = abstractNumbering.createLevel(0, "lowerRoman", "%0.").shadow("pct10", "00FFFF", "FF0000");
+                const tree = new Formatter().format(level);
+                expect(tree["w:lvl"]).to.include({
+                    "w:rPr": [{ "w:shd ": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
+                });
+            });
+
             describe("#underline", () => {
                 it("should set underline to 'single' if no arguments are given", () => {
                     const abstractNumbering = new AbstractNumbering(1);

--- a/src/file/paragraph/run/formatting.ts
+++ b/src/file/paragraph/run/formatting.ts
@@ -113,7 +113,7 @@ export class Imprint extends XmlComponent {
     }
 }
 
-export class Shadow extends XmlComponent {
+/* export class Shadow extends XmlComponent {
     constructor() {
         super("w:shadow");
         this.root.push(
@@ -122,7 +122,7 @@ export class Shadow extends XmlComponent {
             }),
         );
     }
-}
+} */
 
 export class SmallCaps extends XmlComponent {
     constructor() {
@@ -174,6 +174,54 @@ export class RightToLeft extends XmlComponent {
         this.root.push(
             new Attributes({
                 val: true,
+            }),
+        );
+    }
+}
+
+export class Highlight extends XmlComponent {
+    constructor(color: string) {
+        super("w:highlight");
+        this.root.push(
+            new Attributes({
+                val: color,
+            }),
+        );
+    }
+}
+
+export class HighlightComplexScript extends XmlComponent {
+    constructor(color: string) {
+        super("w:highlightCs");
+        this.root.push(
+            new Attributes({
+                val: color,
+            }),
+        );
+    }
+}
+
+export class Shadow extends XmlComponent {
+    constructor(value: string, fill: string, color: string) {
+        super("w:shd");
+        this.root.push(
+            new Attributes({
+                val: value,
+                fill: fill,
+                color: color,
+            }),
+        );
+    }
+}
+
+export class ShadowComplexScript extends XmlComponent {
+    constructor(value: string, fill: string, color: string) {
+        super("w:shdCs");
+        this.root.push(
+            new Attributes({
+                val: value,
+                fill: fill,
+                color: color,
             }),
         );
     }

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -123,7 +123,7 @@ describe("Run", () => {
                 "w:r": [
                     {
                         "w:rPr": [
-                            { "w:highlight ": { _attr: { "w:val": "005599" } } },
+                            { "w:highlight": { _attr: { "w:val": "005599" } } },
                             {
                                 "w:highlightCs": {
                                     _attr: {
@@ -146,7 +146,7 @@ describe("Run", () => {
                 "w:r": [
                     {
                         "w:rPr": [
-                            { "w:shd ": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } },
+                            { "w:shd": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } },
                             {
                                 "w:shdCs": {
                                     _attr: {

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -115,6 +115,54 @@ describe("Run", () => {
         });
     });
 
+    describe("#highlight()", () => {
+        it("it should add highlight to the properties", () => {
+            run.highlight("005599");
+            const tree = new Formatter().format(run);
+            expect(tree).to.deep.equal({
+                "w:r": [
+                    {
+                        "w:rPr": [
+                            { "w:highlight ": { _attr: { "w:val": "005599" } } },
+                            {
+                                "w:highlightCs": {
+                                    _attr: {
+                                        "w:val": "005599",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("#shadow()", () => {
+        it("it should add shadow to the properties", () => {
+            run.shadow("pct10", "00FFFF", "FF0000");
+            const tree = new Formatter().format(run);
+            expect(tree).to.deep.equal({
+                "w:r": [
+                    {
+                        "w:rPr": [
+                            { "w:shd ": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } },
+                            {
+                                "w:shdCs": {
+                                    _attr: {
+                                        "w:val": "pct10",
+                                        "w:fill": "00FFFF",
+                                        "w:color": "FF0000",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+    });
+
     describe("#break()", () => {
         it("it should add break to the run", () => {
             run.break();

--- a/src/file/paragraph/run/run.ts
+++ b/src/file/paragraph/run/run.ts
@@ -7,9 +7,13 @@ import {
     BoldComplexScript,
     Color,
     DoubleStrike,
+    Highlight,
+    HighlightComplexScript,
     Italics,
     ItalicsComplexScript,
     RightToLeft,
+    Shadow,
+    ShadowComplexScript,
     Size,
     SizeComplexScript,
     Strike,
@@ -129,6 +133,18 @@ export class Run extends XmlComponent {
 
     public style(styleId: string): Run {
         this.properties.push(new Style(styleId));
+        return this;
+    }
+
+    public highlight(color: string): Run {
+        this.properties.push(new Highlight(color));
+        this.properties.push(new HighlightComplexScript(color));
+        return this;
+    }
+
+    public shadow(value: string, fill: string, color: string): Run {
+        this.properties.push(new Shadow(value, fill, color));
+        this.properties.push(new ShadowComplexScript(value, fill, color));
         return this;
     }
 }

--- a/src/file/styles/style/character-style.spec.ts
+++ b/src/file/styles/style/character-style.spec.ts
@@ -307,5 +307,51 @@ describe("CharacterStyle", () => {
                 ],
             });
         });
+
+        it("#highlight", () => {
+            const style = new CharacterStyle("myStyleId").highlight("005599");
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "character", "w:styleId": "myStyleId" } },
+                    {
+                        "w:rPr": [{ "w:highlight": { _attr: { "w:val": "005599" } } }],
+                    },
+                    {
+                        "w:uiPriority": {
+                            _attr: {
+                                "w:val": "99",
+                            },
+                        },
+                    },
+                    {
+                        "w:unhideWhenUsed": EMPTY_OBJECT,
+                    },
+                ],
+            });
+        });
+
+        it("#shadow", () => {
+            const style = new CharacterStyle("myStyleId").shadow("pct10", "00FFFF", "FF0000");
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "character", "w:styleId": "myStyleId" } },
+                    {
+                        "w:rPr": [{ "w:shd": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
+                    },
+                    {
+                        "w:uiPriority": {
+                            _attr: {
+                                "w:val": "99",
+                            },
+                        },
+                    },
+                    {
+                        "w:unhideWhenUsed": EMPTY_OBJECT,
+                    },
+                ],
+            });
+        });
     });
 });

--- a/src/file/styles/style/character-style.ts
+++ b/src/file/styles/style/character-style.ts
@@ -58,4 +58,12 @@ export class CharacterStyle extends Style {
         this.root.push(new SemiHidden());
         return this;
     }
+
+    public highlight(color: string): CharacterStyle {
+        return this.addRunProperty(new formatting.Highlight(color));
+    }
+
+    public shadow(value: string, fill: string, color: string): CharacterStyle {
+        return this.addRunProperty(new formatting.Shadow(value, fill, color));
+    }
 }

--- a/src/file/styles/style/paragraph-style.spec.ts
+++ b/src/file/styles/style/paragraph-style.spec.ts
@@ -375,6 +375,32 @@ describe("ParagraphStyle", () => {
             });
         });
 
+        it("#highlight", () => {
+            const style = new ParagraphStyle("myStyleId").highlight("005599");
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
+                    {
+                        "w:rPr": [{ "w:highlight ": { _attr: { "w:val": "005599" } } }],
+                    },
+                ],
+            });
+        });
+
+        it("#shadow", () => {
+            const style = new ParagraphStyle("myStyleId").shadow("pct10", "00FFFF", "FF0000");
+            const tree = new Formatter().format(style);
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
+                    {
+                        "w:rPr": [{ "w:shd ": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
+                    },
+                ],
+            });
+        });
+
         describe("#underline", () => {
             it("should set underline to 'single' if no arguments are given", () => {
                 const style = new ParagraphStyle("myStyleId").underline();

--- a/src/file/styles/style/paragraph-style.spec.ts
+++ b/src/file/styles/style/paragraph-style.spec.ts
@@ -382,7 +382,7 @@ describe("ParagraphStyle", () => {
                 "w:style": [
                     { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
                     {
-                        "w:rPr": [{ "w:highlight ": { _attr: { "w:val": "005599" } } }],
+                        "w:rPr": [{ "w:highlight": { _attr: { "w:val": "005599" } } }],
                     },
                 ],
             });
@@ -395,7 +395,7 @@ describe("ParagraphStyle", () => {
                 "w:style": [
                     { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
                     {
-                        "w:rPr": [{ "w:shd ": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
+                        "w:rPr": [{ "w:shd": { _attr: { "w:val": "pct10", "w:fill": "00FFFF", "w:color": "FF0000" } } }],
                     },
                 ],
             });

--- a/src/file/styles/style/paragraph-style.ts
+++ b/src/file/styles/style/paragraph-style.ts
@@ -114,6 +114,14 @@ export class ParagraphStyle extends Style {
         return this.addRunProperty(new formatting.CharacterSpacing(value));
     }
 
+    public highlight(color: string): ParagraphStyle {
+        return this.addRunProperty(new formatting.Highlight(color));
+    }
+
+    public shadow(value: string, fill: string, color: string): ParagraphStyle {
+        return this.addRunProperty(new formatting.Shadow(value, fill, color));
+    }
+
     // --------------------- Paragraph formatting ------------------------ //
 
     public center(): ParagraphStyle {

--- a/src/file/xml-components/attributes.ts
+++ b/src/file/xml-components/attributes.ts
@@ -3,6 +3,7 @@ import { XmlAttributeComponent } from "./default-attributes";
 export interface IAttributesProperties {
     readonly val?: string | number | boolean;
     readonly color?: string;
+    readonly fill?: string;
     readonly space?: string;
     readonly sz?: string;
     readonly type?: string;
@@ -26,6 +27,7 @@ export class Attributes extends XmlAttributeComponent<IAttributesProperties> {
     protected readonly xmlKeys = {
         val: "w:val",
         color: "w:color",
+        fill: "w:fill",
         space: "w:space",
         sz: "w:sz",
         type: "w:type",


### PR DESCRIPTION
#  Add Highlighting and Shading to the the styling options
Styles now has Highlight and Shadow
Closes #305, #309 

## _Examples_

#### Highlighting:
`this.doc.Styles.createCharacterStyle('myStyle').highlight('yellow');`
```
this.doc.addParagraph(
    new Paragraph()
      .addRun(
        new TextRun('test')
          .highlight('yellow')
          )
      .right()
  )
```

#### Shading:
`this.doc.Styles.createCharacterStyle('myStyle').shadow('pct10','00FFFF','FF0000');`
```
this.doc.addParagraph(
    new Paragraph()
      .addRun(
        new TextRun('test')
           .shadow('pct10','00FFFF','FF0000')
      )
      .right()
  )
```

## _Attributes_

#### Highlighting:
The single attribute `color` specifies the color of the text highlighting. Possible values are: `black`, `blue`, `cyan`, `darkBlue`, `darkCyan`, `darkGray`, `darkGreen`, `darkMagenta`, `darkRed`, `darkYellow`, `green`, `lightGray`, `magenta`, `none`, `red`, `white`, `yellow`.

#### Shading:

Attribute | Description
-- | --
fill | Specifies the color to be used for the background. Values are given as hex values (i.e., in RRGGBB format). No `#`, unlike hex values in HTML/CSS. E.g., `fill="FFFF00"`.
color | Specifies the color to be used for any foreground pattern specified with the val attribute. Values are given as hex values (in RRGGBB format). No `#`, unlike hex values in HTML/CSS. E.g., `fill="FFFF00"`.
value | Specifies the pattern to be used to lay the pattern color over the background color. For example, `value="pct10"` indicates that the border style is a 10 percent foreground fill mask. Possible values are: `clear` (no pattern), `pct10`, `pct12`, `pct15` . . ., `diagCross`, `diagStripe`, `horzCross`, `horzStripe`, `nil`, `thinDiagCross`, `solid`, etc. See ECMA-376, 3rd, § 17.18.78 for a complete listing.
