### PR TITLE
Static Packer

### DIFF
--- a/demo/1-basic.ts
+++ b/demo/1-basic.ts
@@ -24,8 +24,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/10-my-cv.ts
+++ b/demo/10-my-cv.ts
@@ -336,8 +336,6 @@ const documentCreator = new DocumentCreator();
 
 const doc = documentCreator.create([experiences, education, skills, achievements]);
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/11-declaritive-styles-2.ts
+++ b/demo/11-declaritive-styles-2.ts
@@ -163,8 +163,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/12-scaling-images.ts
+++ b/demo/12-scaling-images.ts
@@ -14,8 +14,6 @@ doc.addSection({
     children: [new Paragraph("Hello World"), new Paragraph(image), new Paragraph(image2), new Paragraph(image3), new Paragraph(image4)],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/13-xml-styles.ts
+++ b/demo/13-xml-styles.ts
@@ -27,8 +27,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/14-page-numbers.ts
+++ b/demo/14-page-numbers.ts
@@ -32,8 +32,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/15-page-break-before.ts
+++ b/demo/15-page-break-before.ts
@@ -15,8 +15,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/16-multiple-sections.ts
+++ b/demo/16-multiple-sections.ts
@@ -107,8 +107,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/17-footnotes.ts
+++ b/demo/17-footnotes.ts
@@ -12,8 +12,6 @@ doc.addSection({
 doc.createFootnote(new Paragraph("Test"));
 doc.createFootnote(new Paragraph("My amazing reference"));
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/18-image-from-buffer.ts
+++ b/demo/18-image-from-buffer.ts
@@ -17,8 +17,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/19-export-to-base64.ts
+++ b/demo/19-export-to-base64.ts
@@ -23,8 +23,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBase64String(doc).then((str) => {
+Packer.toBase64String(doc).then((str) => {
     fs.writeFileSync("My Document.docx", str);
 });

--- a/demo/2-declaritive-styles.ts
+++ b/demo/2-declaritive-styles.ts
@@ -117,8 +117,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/20-table-cell-borders.ts
+++ b/demo/20-table-cell-borders.ts
@@ -19,8 +19,6 @@ table
     .addStartBorder(BorderStyle.DOT_DOT_DASH, 3, "green")
     .addEndBorder(BorderStyle.DOT_DOT_DASH, 3, "#ff8000");
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/21-bookmarks.ts
+++ b/demo/21-bookmarks.ts
@@ -30,8 +30,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/22-right-to-left-text.ts
+++ b/demo/22-right-to-left-text.ts
@@ -39,8 +39,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/23-base64-images.ts
+++ b/demo/23-base64-images.ts
@@ -27,8 +27,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/24-images-to-table-cell.ts
+++ b/demo/24-images-to-table-cell.ts
@@ -19,8 +19,6 @@ table.getCell(2, 2).add(new Paragraph("Hello"));
 const image = Media.addImage(doc, fs.readFileSync("./demo/images/image1.jpeg"));
 table.getCell(1, 1).add(new Paragraph(image));
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/26-paragraph-borders.ts
+++ b/demo/26-paragraph-borders.ts
@@ -28,8 +28,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/27-declaritive-styles-3.ts
+++ b/demo/27-declaritive-styles-3.ts
@@ -37,8 +37,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/28-table-of-contents.ts
+++ b/demo/28-table-of-contents.ts
@@ -48,12 +48,9 @@ doc.addSection({
             style: "MySpectacularStyle",
             pageBreakBefore: true,
         }),
-
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/29-numbered-lists.ts
+++ b/demo/29-numbered-lists.ts
@@ -61,8 +61,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/3-numbering-and-bullet-points.ts
+++ b/demo/3-numbering-and-bullet-points.ts
@@ -71,8 +71,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/30-template-document.ts
+++ b/demo/30-template-document.ts
@@ -23,8 +23,7 @@ fs.readFile(filePath, (err, data) => {
             children: [new Paragraph("Hello World")],
         });
 
-        const packer = new Packer();
-        packer.toBuffer(doc).then((buffer) => {
+        Packer.toBuffer(doc).then((buffer) => {
             fs.writeFileSync("My Document.docx", buffer);
         });
     });

--- a/demo/31-tables.ts
+++ b/demo/31-tables.ts
@@ -27,8 +27,6 @@ doc.addSection({
     children: [table],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/32-merge-table-cells.ts
+++ b/demo/32-merge-table-cells.ts
@@ -108,8 +108,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/33-sequential-captions.ts
+++ b/demo/33-sequential-captions.ts
@@ -26,8 +26,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/34-floating-tables.ts
+++ b/demo/34-floating-tables.ts
@@ -36,8 +36,6 @@ doc.addSection({
     children: [table],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/35-hyperlinks.ts
+++ b/demo/35-hyperlinks.ts
@@ -12,8 +12,6 @@ doc.addSection({
     children: [paragraph],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/36-image-to-table-cell.ts
+++ b/demo/36-image-to-table-cell.ts
@@ -22,8 +22,6 @@ doc.addSection({
     children: [table],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/37-images-to-header-and-footer.ts
+++ b/demo/37-images-to-header-and-footer.ts
@@ -17,8 +17,6 @@ doc.addSection({
     children: [new Paragraph("Hello World")],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/38-text-wrapping.ts
+++ b/demo/38-text-wrapping.ts
@@ -40,8 +40,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/39-page-numbers.ts
+++ b/demo/39-page-numbers.ts
@@ -40,8 +40,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/4-basic-table.ts
+++ b/demo/4-basic-table.ts
@@ -16,8 +16,6 @@ doc.addSection({
     children: [table],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/40-line-numbers.ts
+++ b/demo/40-line-numbers.ts
@@ -24,8 +24,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/41-merge-table-cells-2.ts
+++ b/demo/41-merge-table-cells-2.ts
@@ -49,8 +49,6 @@ doc.addSection({
     children: [table],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/43-images-to-table-cell-2.ts
+++ b/demo/43-images-to-table-cell-2.ts
@@ -17,8 +17,6 @@ doc.addSection({
     children: [table],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/44-multiple-columns.ts
+++ b/demo/44-multiple-columns.ts
@@ -35,8 +35,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/45-highlighting-text.ts
+++ b/demo/45-highlighting-text.ts
@@ -30,8 +30,6 @@ doc.addSection({
     children: [],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/46-shading-text.ts
+++ b/demo/46-shading-text.ts
@@ -34,8 +34,6 @@ doc.addSection({
     children: [],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/5-images.ts
+++ b/demo/5-images.ts
@@ -57,8 +57,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/6-page-borders.ts
+++ b/demo/6-page-borders.ts
@@ -35,8 +35,6 @@ doc.addSection({
     ],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/7-landscape.ts
+++ b/demo/7-landscape.ts
@@ -12,8 +12,6 @@ doc.addSection({
     children: [new Paragraph("Hello World")],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/8-header-footer.ts
+++ b/demo/8-header-footer.ts
@@ -19,8 +19,6 @@ doc.addSection({
     children: [new Paragraph("Hello World")],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/9-images-in-header-and-footer.ts
+++ b/demo/9-images-in-header-and-footer.ts
@@ -30,8 +30,6 @@ doc.addSection({
     children: [new Paragraph("Hello World")],
 });
 
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });

--- a/demo/browser-demo.html
+++ b/demo/browser-demo.html
@@ -32,9 +32,9 @@
                     ],
                 });
 
-                const packer = new Packer();
 
-                packer.toBlob(doc).then((blob) => {
+
+                Packer.toBlob(doc).then((blob) => {
                     console.log(blob);
                     saveAs(blob, "example.docx");
                     console.log("Document created successfully");

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,9 +59,7 @@ doc.addSection({
 });
 
 // Used to export the file into a .docx file
-const packer = new Packer();
-
-packer.toBuffer(doc).then((buffer) => {
+Packer.toBuffer(doc).then((buffer) => {
     fs.writeFileSync("My Document.docx", buffer);
 });
 

--- a/docs/usage/packers.md
+++ b/docs/usage/packers.md
@@ -2,9 +2,44 @@
 
 > Packers are the way in which `docx` turns your code into `.docx` format. It is completely decoupled from the `docx.Document`.
 
+Packers in `version 4` and above are now one single `Packer`. It works in both a node and browser environment (Angular etc). Now, the packer returns a `Buffer`, `Blob` or `base64 string`. It is up to you to take that and persist it with node's `fs`, send it down as a downloadable file, or anything else you wish. As of version 4, this library will not have options to export to PDF.
+
+## Version 5
+
+Packers in `version 5` and above are now static methods on `Packer`.
+
+### Export as Buffer
+
+This will return a NodeJS `Buffer`. If this is used in the browser, it will return a `UInt8Array` instead.
+
+```ts
+Packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});
+```
+
+### Export as a `base64` string
+
+```ts
+Packer.toBase64String(doc).then((string) => {
+    console.log(string);
+});
+```
+
+### Export as Blob
+
+This is useful if you want to send it as an downloadable in a browser environment.
+
+```ts
+Packer.toBlob(doc).then((blob) => {
+    // saveAs from FileSaver will download the file
+    saveAs(blob, "example.docx");
+});
+```
+
 ## Version 4
 
-Packers in `version 4` and above are now one single `Packer`. It works in both a node and browser environment (Angular etc). Now, the packer returns a `Buffer`, `Blob` or `base64 string`. It is up to you to take that and persist it with node's `fs`, send it down as a downloadable file, or anything else you wish. As of version 4, this library will not have options to export to PDF.
+The `Packer` in `version 4` requires an instance of `Packer`, so be sure to `new` it.
 
 ### Export as Buffer
 

--- a/docs/usage/styling-with-js.md
+++ b/docs/usage/styling-with-js.md
@@ -107,8 +107,7 @@ There are three parts to using custom styles with `docx`:
 3.  When you generate your document, make sure to pass the `styles` container to the `Packer`:
 
     ```ts
-    const packer = new Packer(doc, myStyles);
-    packer.pack(myOutStream);
+    Packer.pack(myOutStream);
     ```
 
 **Note**: If you are using the `.headingX` or `.title` methods of paragraphs, you must make sure to define `HeadingX` or `Title` styles for these. Otherwise they'll show up unstyled :(. If you are using the `.bullet` or `.setNumbering` methods, you need to define a `ListParagraph` style or the numbers may not show up.

--- a/src/export/packer/next-compiler.ts
+++ b/src/export/packer/next-compiler.ts
@@ -30,17 +30,15 @@ interface IXmlifyedFileMapping {
 export class Compiler {
     private readonly formatter: Formatter;
     private readonly imageReplacer: ImageReplacer;
-    private readonly prettifyXml?: boolean;
 
-    constructor(prettifyXml?: boolean) {
+    constructor() {
         this.formatter = new Formatter();
         this.imageReplacer = new ImageReplacer();
-        this.prettifyXml = prettifyXml;
     }
 
-    public compile(file: File): JSZip {
+    public compile(file: File, prettifyXml?: boolean): JSZip {
         const zip = new JSZip();
-        const xmlifiedFileMapping = this.xmlifyFile(file);
+        const xmlifiedFileMapping = this.xmlifyFile(file, prettifyXml);
 
         for (const key in xmlifiedFileMapping) {
             if (!xmlifiedFileMapping[key]) {
@@ -66,14 +64,14 @@ export class Compiler {
         return zip;
     }
 
-    private xmlifyFile(file: File): IXmlifyedFileMapping {
+    private xmlifyFile(file: File, prettify?: boolean): IXmlifyedFileMapping {
         file.verifyUpdateFields();
         const documentRelationshipCount = file.DocumentRelationships.RelationshipCount + 1;
 
         return {
             Relationships: {
                 data: (() => {
-                    const xmlData = xml(this.formatter.format(file.Document), this.prettifyXml);
+                    const xmlData = xml(this.formatter.format(file.Document), prettify);
                     const mediaDatas = this.imageReplacer.getMediaData(xmlData, file.Media);
 
                     mediaDatas.forEach((mediaData, i) => {
@@ -84,13 +82,13 @@ export class Compiler {
                         );
                     });
 
-                    return xml(this.formatter.format(file.DocumentRelationships), this.prettifyXml);
+                    return xml(this.formatter.format(file.DocumentRelationships), prettify);
                 })(),
                 path: "word/_rels/document.xml.rels",
             },
             Document: {
                 data: (() => {
-                    const tempXmlData = xml(this.formatter.format(file.Document), this.prettifyXml);
+                    const tempXmlData = xml(this.formatter.format(file.Document), prettify);
                     const mediaDatas = this.imageReplacer.getMediaData(tempXmlData, file.Media);
                     const xmlData = this.imageReplacer.replace(tempXmlData, mediaDatas, documentRelationshipCount);
 
@@ -99,7 +97,7 @@ export class Compiler {
                 path: "word/document.xml",
             },
             Styles: {
-                data: xml(this.formatter.format(file.Styles), this.prettifyXml),
+                data: xml(this.formatter.format(file.Styles), prettify),
                 path: "word/styles.xml",
             },
             Properties: {
@@ -112,15 +110,15 @@ export class Compiler {
                 path: "docProps/core.xml",
             },
             Numbering: {
-                data: xml(this.formatter.format(file.Numbering), this.prettifyXml),
+                data: xml(this.formatter.format(file.Numbering), prettify),
                 path: "word/numbering.xml",
             },
             FileRelationships: {
-                data: xml(this.formatter.format(file.FileRelationships), this.prettifyXml),
+                data: xml(this.formatter.format(file.FileRelationships), prettify),
                 path: "_rels/.rels",
             },
             HeaderRelationships: file.Headers.map((headerWrapper, index) => {
-                const xmlData = xml(this.formatter.format(headerWrapper.Header), this.prettifyXml);
+                const xmlData = xml(this.formatter.format(headerWrapper.Header), prettify);
                 const mediaDatas = this.imageReplacer.getMediaData(xmlData, file.Media);
 
                 mediaDatas.forEach((mediaData, i) => {
@@ -132,12 +130,12 @@ export class Compiler {
                 });
 
                 return {
-                    data: xml(this.formatter.format(headerWrapper.Relationships), this.prettifyXml),
+                    data: xml(this.formatter.format(headerWrapper.Relationships), prettify),
                     path: `word/_rels/header${index + 1}.xml.rels`,
                 };
             }),
             FooterRelationships: file.Footers.map((footerWrapper, index) => {
-                const xmlData = xml(this.formatter.format(footerWrapper.Footer), this.prettifyXml);
+                const xmlData = xml(this.formatter.format(footerWrapper.Footer), prettify);
                 const mediaDatas = this.imageReplacer.getMediaData(xmlData, file.Media);
 
                 mediaDatas.forEach((mediaData, i) => {
@@ -149,12 +147,12 @@ export class Compiler {
                 });
 
                 return {
-                    data: xml(this.formatter.format(footerWrapper.Relationships), this.prettifyXml),
+                    data: xml(this.formatter.format(footerWrapper.Relationships), prettify),
                     path: `word/_rels/footer${index + 1}.xml.rels`,
                 };
             }),
             Headers: file.Headers.map((headerWrapper, index) => {
-                const tempXmlData = xml(this.formatter.format(headerWrapper.Header), this.prettifyXml);
+                const tempXmlData = xml(this.formatter.format(headerWrapper.Header), prettify);
                 const mediaDatas = this.imageReplacer.getMediaData(tempXmlData, file.Media);
                 // TODO: 0 needs to be changed when headers get relationships of their own
                 const xmlData = this.imageReplacer.replace(tempXmlData, mediaDatas, 0);
@@ -165,7 +163,7 @@ export class Compiler {
                 };
             }),
             Footers: file.Footers.map((footerWrapper, index) => {
-                const tempXmlData = xml(this.formatter.format(footerWrapper.Footer), this.prettifyXml);
+                const tempXmlData = xml(this.formatter.format(footerWrapper.Footer), prettify);
                 const mediaDatas = this.imageReplacer.getMediaData(tempXmlData, file.Media);
                 // TODO: 0 needs to be changed when headers get relationships of their own
                 const xmlData = this.imageReplacer.replace(tempXmlData, mediaDatas, 0);
@@ -176,19 +174,19 @@ export class Compiler {
                 };
             }),
             ContentTypes: {
-                data: xml(this.formatter.format(file.ContentTypes), this.prettifyXml),
+                data: xml(this.formatter.format(file.ContentTypes), prettify),
                 path: "[Content_Types].xml",
             },
             AppProperties: {
-                data: xml(this.formatter.format(file.AppProperties), this.prettifyXml),
+                data: xml(this.formatter.format(file.AppProperties), prettify),
                 path: "docProps/app.xml",
             },
             FootNotes: {
-                data: xml(this.formatter.format(file.FootNotes), this.prettifyXml),
+                data: xml(this.formatter.format(file.FootNotes), prettify),
                 path: "word/footnotes.xml",
             },
             Settings: {
-                data: xml(this.formatter.format(file.Settings), this.prettifyXml),
+                data: xml(this.formatter.format(file.Settings), prettify),
                 path: "word/settings.xml",
             },
         };

--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -53,6 +53,11 @@ describe("Packer", () => {
                 assert.isDefined(error);
             });
         });
+
+        after(() => {
+            // tslint:disable-next-line:no-any
+            (Packer as any).compiler.compile.restore();
+        });
     });
 
     describe("#toBase64String()", () => {
@@ -72,6 +77,11 @@ describe("Packer", () => {
             return Packer.toBase64String(file).catch((error) => {
                 assert.isDefined(error);
             });
+        });
+
+        after(() => {
+            // tslint:disable-next-line:no-any
+            (Packer as any).compiler.compile.restore();
         });
     });
 });

--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -7,7 +7,6 @@ import { File, HeadingLevel, Paragraph } from "file";
 import { Packer } from "./packer";
 
 describe("Packer", () => {
-    let packer: Packer;
     let file: File;
 
     beforeEach(() => {
@@ -34,14 +33,12 @@ describe("Packer", () => {
                 new Paragraph("test text"),
             ],
         });
-
-        packer = new Packer();
     });
 
     describe("#toBuffer()", () => {
         it("should create a standard docx file", async function() {
             this.timeout(99999999);
-            const buffer = await packer.toBuffer(file);
+            const buffer = await Packer.toBuffer(file);
 
             assert.isDefined(buffer);
             assert.isTrue(buffer.byteLength > 0);
@@ -49,10 +46,10 @@ describe("Packer", () => {
 
         it("should handle exception if it throws any", () => {
             // tslint:disable-next-line:no-any
-            const compiler = stub((packer as any).compiler, "compile");
+            const compiler = stub((Packer as any).compiler, "compile");
 
             compiler.throwsException();
-            return packer.toBuffer(file).catch((error) => {
+            return Packer.toBuffer(file).catch((error) => {
                 assert.isDefined(error);
             });
         });
@@ -61,7 +58,7 @@ describe("Packer", () => {
     describe("#toBase64String()", () => {
         it("should create a standard docx file", async function() {
             this.timeout(99999999);
-            const str = await packer.toBase64String(file);
+            const str = await Packer.toBase64String(file);
 
             assert.isDefined(str);
             assert.isTrue(str.length > 0);
@@ -69,10 +66,10 @@ describe("Packer", () => {
 
         it("should handle exception if it throws any", () => {
             // tslint:disable-next-line:no-any
-            const compiler = stub((packer as any).compiler, "compile");
+            const compiler = stub((Packer as any).compiler, "compile");
 
             compiler.throwsException();
-            return packer.toBase64String(file).catch((error) => {
+            return Packer.toBase64String(file).catch((error) => {
                 assert.isDefined(error);
             });
         });

--- a/src/export/packer/packer.ts
+++ b/src/export/packer/packer.ts
@@ -2,14 +2,8 @@ import { File } from "file";
 import { Compiler } from "./next-compiler";
 
 export class Packer {
-    private readonly compiler: Compiler;
-
-    constructor(prettifyXml?: boolean) {
-        this.compiler = new Compiler(prettifyXml);
-    }
-
-    public async toBuffer(file: File): Promise<Buffer> {
-        const zip = this.compiler.compile(file);
+    public static async toBuffer(file: File, prettify?: boolean): Promise<Buffer> {
+        const zip = this.compiler.compile(file, prettify);
         const zipData = (await zip.generateAsync({
             type: "nodebuffer",
             mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -18,8 +12,8 @@ export class Packer {
         return zipData;
     }
 
-    public async toBase64String(file: File): Promise<string> {
-        const zip = this.compiler.compile(file);
+    public static async toBase64String(file: File, prettify?: boolean): Promise<string> {
+        const zip = this.compiler.compile(file, prettify);
         const zipData = (await zip.generateAsync({
             type: "base64",
             mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -28,8 +22,8 @@ export class Packer {
         return zipData;
     }
 
-    public async toBlob(file: File): Promise<Blob> {
-        const zip = this.compiler.compile(file);
+    public static async toBlob(file: File, prettify?: boolean): Promise<Blob> {
+        const zip = this.compiler.compile(file, prettify);
         const zipData = (await zip.generateAsync({
             type: "blob",
             mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -37,4 +31,6 @@ export class Packer {
 
         return zipData;
     }
+
+    private static readonly compiler = new Compiler();
 }


### PR DESCRIPTION
Rationale behind this is that there is only one `Packer`, and that Packer has no state, and is only utility functions.

It seems like a waste to create a new instance of it.

Therefore a utility function fits the purpose a bit more.

The original reason of why you needed an instance of the Packer was because there were many types of Packers in version 3, and the Packer was intended to be a sort of interface between all the different type of Packers

And also it needed constructor parameters before