### PR TITLE
Fix table of contents \t flag

### DIFF
--- a/src/file/table-of-contents/field-instruction.ts
+++ b/src/file/table-of-contents/field-instruction.ts
@@ -52,7 +52,7 @@ export class FieldInstruction extends XmlComponent {
             instruction = `${instruction} \\s "${this.properties.seqFieldIdentifierForPrefix}"`;
         }
         if (this.properties.stylesWithLevels && this.properties.stylesWithLevels.length) {
-            const styles = this.properties.stylesWithLevels.map((sl) => `${sl.styleName};${sl.level}`).join(";");
+            const styles = this.properties.stylesWithLevels.map((sl) => `${sl.styleName},${sl.level}`).join(",");
             instruction = `${instruction} \\t "${styles}"`;
         }
         if (this.properties.useAppliedParagraphOutlineLevel) {

--- a/src/file/table-of-contents/table-of-contents.spec.ts
+++ b/src/file/table-of-contents/table-of-contents.spec.ts
@@ -146,7 +146,7 @@ const COMPLETE_TOC = {
                                                 "xml:space": "preserve",
                                             },
                                         },
-                                        'TOC \\a "A" \\b "B" \\c "C" \\d "D" \\f "F" \\h \\l "L" \\n "N" \\o "O" \\p "P" \\s "S" \\t "SL;1;SL;2" \\u \\w \\x \\z',
+                                        'TOC \\a "A" \\b "B" \\c "C" \\d "D" \\f "F" \\h \\l "L" \\n "N" \\o "O" \\p "P" \\s "S" \\t "SL,1,SL,2" \\u \\w \\x \\z',
                                     ],
                                 },
                                 {


### PR DESCRIPTION
Use comma separated doublets (as described here: http://officeopenxml.com/WPtableOfContents.php) as opposed to semicolon separated.