### PR TITLE
Add ability to vertically align content of section

### DIFF
--- a/demo/48-vertical-align.ts
+++ b/demo/48-vertical-align.ts
@@ -1,0 +1,31 @@
+// Example of making content of section vertically aligned
+// Import from 'docx' rather than '../build' if you install from npm
+import * as fs from "fs";
+import { Document, Packer, Paragraph, SectionVerticalAlignValue, TextRun } from "../build";
+
+const doc = new Document();
+
+doc.addSection({
+    properties: {
+        valign: SectionVerticalAlignValue.Center,
+    },
+    children: [
+        new Paragraph({
+            children: [
+                new TextRun("Hello World"),
+                new TextRun({
+                    text: "Foo Bar",
+                    bold: true,
+                }),
+                new TextRun({
+                    text: "Github is the best",
+                    bold: true,
+                }).tab(),
+            ],
+        }),
+    ],
+});
+
+Packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});

--- a/demo/48-vertical-align.ts
+++ b/demo/48-vertical-align.ts
@@ -7,7 +7,7 @@ const doc = new Document();
 
 doc.addSection({
     properties: {
-        valign: SectionVerticalAlignValue.Center,
+        verticalAlign: SectionVerticalAlignValue.CENTER,
     },
     children: [
         new Paragraph({

--- a/src/file/document/body/section-properties/index.ts
+++ b/src/file/document/body/section-properties/index.ts
@@ -5,3 +5,4 @@ export * from "./page-size";
 export * from "./page-number";
 export * from "./page-border";
 export * from "./line-number";
+export * from "./vertical-align";

--- a/src/file/document/body/section-properties/section-properties.spec.ts
+++ b/src/file/document/body/section-properties/section-properties.spec.ts
@@ -8,6 +8,7 @@ import { Media } from "file/media";
 import { PageBorderOffsetFrom } from "./page-border";
 import { PageNumberFormat } from "./page-number";
 import { SectionProperties } from "./section-properties";
+import { SectionVerticalAlignValue } from "./vertical-align";
 
 describe("SectionProperties", () => {
     describe("#constructor()", () => {
@@ -39,6 +40,7 @@ describe("SectionProperties", () => {
                 pageNumberStart: 10,
                 pageNumberFormatType: PageNumberFormat.CARDINAL_TEXT,
                 titlePage: true,
+                verticalAlign: SectionVerticalAlignValue.TOP,
             });
             const tree = new Formatter().format(properties);
             expect(Object.keys(tree)).to.deep.equal(["w:sectPr"]);

--- a/src/file/document/body/section-properties/section-properties.ts
+++ b/src/file/document/body/section-properties/section-properties.ts
@@ -89,7 +89,7 @@ export class SectionProperties extends XmlComponent {
             pageBorderBottom,
             pageBorderLeft,
             titlePage = false,
-            valign,
+            verticalAlign,
         } = options;
 
         this.options = options;
@@ -125,8 +125,8 @@ export class SectionProperties extends XmlComponent {
             this.root.push(new TitlePage());
         }
 
-        if (valign) {
-            this.root.push(new SectionVerticalAlign(valign));
+        if (verticalAlign) {
+            this.root.push(new SectionVerticalAlign(verticalAlign));
         }
     }
 

--- a/src/file/document/body/section-properties/section-properties.ts
+++ b/src/file/document/body/section-properties/section-properties.ts
@@ -18,6 +18,7 @@ import { IPageNumberTypeAttributes, PageNumberType } from "./page-number";
 import { PageSize } from "./page-size/page-size";
 import { IPageSizeAttributes, PageOrientation } from "./page-size/page-size-attributes";
 import { TitlePage } from "./title-page/title-page";
+import { ISectionVerticalAlignAttributes, SectionVerticalAlign } from "./vertical-align";
 
 export interface IHeaderFooterGroup<T> {
     readonly default?: T;
@@ -45,7 +46,8 @@ export type SectionPropertiesOptions = IPageSizeAttributes &
     IPageNumberTypeAttributes &
     ILineNumberAttributes &
     IPageBordersOptions &
-    ITitlePageOptions & {
+    ITitlePageOptions &
+    ISectionVerticalAlignAttributes & {
         readonly column?: {
             readonly space?: number;
             readonly count?: number;
@@ -87,6 +89,7 @@ export class SectionProperties extends XmlComponent {
             pageBorderBottom,
             pageBorderLeft,
             titlePage = false,
+            valign,
         } = options;
 
         this.options = options;
@@ -120,6 +123,10 @@ export class SectionProperties extends XmlComponent {
 
         if (titlePage) {
             this.root.push(new TitlePage());
+        }
+
+        if (valign) {
+            this.root.push(new SectionVerticalAlign(valign));
         }
     }
 

--- a/src/file/document/body/section-properties/vertical-align/index.ts
+++ b/src/file/document/body/section-properties/vertical-align/index.ts
@@ -1,0 +1,2 @@
+export * from "./vertical-align";
+export * from "./vertical-align-attributes";

--- a/src/file/document/body/section-properties/vertical-align/vertical-align-attributes.ts
+++ b/src/file/document/body/section-properties/vertical-align/vertical-align-attributes.ts
@@ -1,0 +1,12 @@
+import { XmlAttributeComponent } from "file/xml-components";
+import { SectionVerticalAlignValue } from "./vertical-align";
+
+export interface ISectionVerticalAlignAttributes {
+    readonly valign?: SectionVerticalAlignValue;
+}
+
+export class SectionVerticalAlignAttributes extends XmlAttributeComponent<ISectionVerticalAlignAttributes> {
+    protected readonly xmlKeys = {
+        valign: "w:val",
+    };
+}

--- a/src/file/document/body/section-properties/vertical-align/vertical-align-attributes.ts
+++ b/src/file/document/body/section-properties/vertical-align/vertical-align-attributes.ts
@@ -2,11 +2,11 @@ import { XmlAttributeComponent } from "file/xml-components";
 import { SectionVerticalAlignValue } from "./vertical-align";
 
 export interface ISectionVerticalAlignAttributes {
-    readonly valign?: SectionVerticalAlignValue;
+    readonly verticalAlign?: SectionVerticalAlignValue;
 }
 
 export class SectionVerticalAlignAttributes extends XmlAttributeComponent<ISectionVerticalAlignAttributes> {
     protected readonly xmlKeys = {
-        valign: "w:val",
+        verticalAlign: "w:val",
     };
 }

--- a/src/file/document/body/section-properties/vertical-align/vertical-align.ts
+++ b/src/file/document/body/section-properties/vertical-align/vertical-align.ts
@@ -1,0 +1,18 @@
+// http://officeopenxml.com/WPsection.php
+
+import { XmlComponent } from "file/xml-components";
+import { SectionVerticalAlignAttributes } from "./vertical-align-attributes";
+
+export enum SectionVerticalAlignValue {
+    Both = "both",
+    Bottom = "bottom",
+    Center = "center",
+    Top = "top",
+}
+
+export class SectionVerticalAlign extends XmlComponent {
+    constructor(value: SectionVerticalAlignValue) {
+        super("w:vAlign");
+        this.root.push(new SectionVerticalAlignAttributes({ valign: value }));
+    }
+}

--- a/src/file/document/body/section-properties/vertical-align/vertical-align.ts
+++ b/src/file/document/body/section-properties/vertical-align/vertical-align.ts
@@ -4,15 +4,15 @@ import { XmlComponent } from "file/xml-components";
 import { SectionVerticalAlignAttributes } from "./vertical-align-attributes";
 
 export enum SectionVerticalAlignValue {
-    Both = "both",
-    Bottom = "bottom",
-    Center = "center",
-    Top = "top",
+    BOTH = "both",
+    BOTTOM = "bottom",
+    CENTER = "center",
+    TOP = "top",
 }
 
 export class SectionVerticalAlign extends XmlComponent {
     constructor(value: SectionVerticalAlignValue) {
         super("w:vAlign");
-        this.root.push(new SectionVerticalAlignAttributes({ valign: value }));
+        this.root.push(new SectionVerticalAlignAttributes({ verticalAlign: value }));
     }
 }


### PR DESCRIPTION
In my project I need to vertically align the content of the first section in the document. OOXML standard allows us to do it via the `vAlign` property, but `docx.js` is lacking this option right now, so I have added it myself.

The documentation to `vAlign` property is here:
[http://officeopenxml.com/WPsection.php](http://officeopenxml.com/WPsection.php)

@dolanmiu 

I am not very familiar with TypeScript, so I am open to comments and suggestions.