### PR TITLE
Allow image reuse

### DIFF
--- a/src/export/packer/image-replacer.ts
+++ b/src/export/packer/image-replacer.ts
@@ -5,7 +5,7 @@ export class ImageReplacer {
         let currentXmlData = xmlData;
 
         mediaData.forEach((image, i) => {
-            currentXmlData = currentXmlData.replace(new RegExp(`{${image.fileName}}`, 'g'), (offset + i).toString());
+            currentXmlData = currentXmlData.replace(new RegExp(`{${image.fileName}}`, "g"), (offset + i).toString());
         });
 
         return currentXmlData;

--- a/src/export/packer/image-replacer.ts
+++ b/src/export/packer/image-replacer.ts
@@ -5,7 +5,7 @@ export class ImageReplacer {
         let currentXmlData = xmlData;
 
         mediaData.forEach((image, i) => {
-            currentXmlData = currentXmlData.replace(`{${image.fileName}}`, (offset + i).toString());
+            currentXmlData = currentXmlData.replace(new RegExp(`{${image.fileName}}`, 'g'), (offset + i).toString());
         });
 
         return currentXmlData;


### PR DESCRIPTION
If you attempt to reuse an image within a document, all but the first instance of the image will be broken, because subsequent instances do not have their r:embed attribute rewritten to use the sequential ID.

This uses a regex with the global flag set in order to rewrite the r:embed attribute for every instance of the image.