### PR TITLE
Fix for empty first paragraph

### DIFF
--- a/src/file/document/body/body.spec.ts
+++ b/src/file/document/body/body.spec.ts
@@ -23,9 +23,6 @@ describe("Body", () => {
             expect(tree).to.deep.equal({
                 "w:body": [
                     {
-                        "w:p": {},
-                    },
-                    {
                         "w:sectPr": [
                             { "w:pgSz": { _attr: { "w:w": 10000, "w:h": 10000, "w:orient": "portrait" } } },
                             {

--- a/src/file/document/body/body.ts
+++ b/src/file/document/body/body.ts
@@ -26,6 +26,7 @@ export class Body extends XmlComponent {
 
     public prepForXml(): IXmlableObject | undefined {
         if (this.sections.length === 1) {
+            this.root.splice(0, 1);
             this.root.push(this.sections.pop() as SectionProperties);
         }
 

--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -20,8 +20,8 @@ describe("File", () => {
 
             const tree = new Formatter().format(doc.Document.Body);
 
-            expect(tree["w:body"][1]["w:sectPr"][4]["w:headerReference"]._attr["w:type"]).to.equal("default");
-            expect(tree["w:body"][1]["w:sectPr"][5]["w:footerReference"]._attr["w:type"]).to.equal("default");
+            expect(tree["w:body"][0]["w:sectPr"][4]["w:headerReference"]._attr["w:type"]).to.equal("default");
+            expect(tree["w:body"][0]["w:sectPr"][5]["w:footerReference"]._attr["w:type"]).to.equal("default");
         });
 
         it("should create with correct headers and footers", () => {
@@ -39,8 +39,8 @@ describe("File", () => {
 
             const tree = new Formatter().format(doc.Document.Body);
 
-            expect(tree["w:body"][1]["w:sectPr"][4]["w:headerReference"]._attr["w:type"]).to.equal("default");
-            expect(tree["w:body"][1]["w:sectPr"][5]["w:footerReference"]._attr["w:type"]).to.equal("default");
+            expect(tree["w:body"][0]["w:sectPr"][4]["w:headerReference"]._attr["w:type"]).to.equal("default");
+            expect(tree["w:body"][0]["w:sectPr"][5]["w:footerReference"]._attr["w:type"]).to.equal("default");
         });
 
         it("should create with first headers and footers", () => {
@@ -58,8 +58,8 @@ describe("File", () => {
 
             const tree = new Formatter().format(doc.Document.Body);
 
-            expect(tree["w:body"][1]["w:sectPr"][5]["w:headerReference"]._attr["w:type"]).to.equal("first");
-            expect(tree["w:body"][1]["w:sectPr"][7]["w:footerReference"]._attr["w:type"]).to.equal("first");
+            expect(tree["w:body"][0]["w:sectPr"][5]["w:headerReference"]._attr["w:type"]).to.equal("first");
+            expect(tree["w:body"][0]["w:sectPr"][7]["w:footerReference"]._attr["w:type"]).to.equal("first");
         });
 
         it("should create with correct headers", () => {
@@ -81,13 +81,13 @@ describe("File", () => {
 
             const tree = new Formatter().format(doc.Document.Body);
 
-            expect(tree["w:body"][1]["w:sectPr"][4]["w:headerReference"]._attr["w:type"]).to.equal("default");
-            expect(tree["w:body"][1]["w:sectPr"][5]["w:headerReference"]._attr["w:type"]).to.equal("first");
-            expect(tree["w:body"][1]["w:sectPr"][6]["w:headerReference"]._attr["w:type"]).to.equal("even");
+            expect(tree["w:body"][0]["w:sectPr"][4]["w:headerReference"]._attr["w:type"]).to.equal("default");
+            expect(tree["w:body"][0]["w:sectPr"][5]["w:headerReference"]._attr["w:type"]).to.equal("first");
+            expect(tree["w:body"][0]["w:sectPr"][6]["w:headerReference"]._attr["w:type"]).to.equal("even");
 
-            expect(tree["w:body"][1]["w:sectPr"][7]["w:footerReference"]._attr["w:type"]).to.equal("default");
-            expect(tree["w:body"][1]["w:sectPr"][8]["w:footerReference"]._attr["w:type"]).to.equal("first");
-            expect(tree["w:body"][1]["w:sectPr"][9]["w:footerReference"]._attr["w:type"]).to.equal("even");
+            expect(tree["w:body"][0]["w:sectPr"][7]["w:footerReference"]._attr["w:type"]).to.equal("default");
+            expect(tree["w:body"][0]["w:sectPr"][8]["w:footerReference"]._attr["w:type"]).to.equal("first");
+            expect(tree["w:body"][0]["w:sectPr"][9]["w:footerReference"]._attr["w:type"]).to.equal("even");
         });
     });
 


### PR DESCRIPTION
If there is only one section in a document, it always starts with an unnecessary empty paragraph, due to the way adding sections works. This fix simply removes the first element in the body's root array (i.e. the extra paragraph) during XML creation IFF there is only one section in the body. If there are multiple sections, it does nothing.

Will fix https://github.com/dolanmiu/docx/issues/433