### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="description" content="Generate .docx documents with JavaScript">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+    <link 
+        rel="stylesheet"
+        href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+        title="docsify-darklight-theme"
+        type="text/css"
+    />
 </head>
 
 <body>
@@ -26,6 +31,10 @@
     <script src="https://unpkg.com/docsify-copy-code@2"></script>
     <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
     <script src="//unpkg.com/prismjs/components/prism-typescript.min.js"></script>
+    <script 
+        src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+        type="text/javascript">
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79611247-c9e9e000-8117-11ea-806a-164a2d2b584b.png)

After

![image](https://user-images.githubusercontent.com/10001746/79611223-bb9bc400-8117-11ea-990e-2f1be9b9eac8.png)

**Dark Mode :**

![image](https://user-images.githubusercontent.com/10001746/79611308-ee45bc80-8117-11ea-8d9d-4d26f3896767.png)


