### PR TITLE
adds textDirection to table cells

### DIFF
--- a/demo/31-tables.ts
+++ b/demo/31-tables.ts
@@ -18,12 +18,12 @@ const table = new Table({
                     verticalAlign: VerticalAlign.CENTER,
                 }),
                 new TableCell({
-                    children: [new Paragraph({text: "bottom to top"}), new Paragraph({})],
-                    textDirection: TextDirection.BOTTOMTOTOPLEFTTORIGHT
+                    children: [new Paragraph({ text: "bottom to top" }), new Paragraph({})],
+                    textDirection: TextDirection.BOTTOM_TO_TOP_LEFT_TO_RIGHT,
                 }),
                 new TableCell({
-                    children: [new Paragraph({text: "top to bottom"}), new Paragraph({})],
-                    textDirection: TextDirection.TOPTOBOTTOMRIGHTTOLEFT
+                    children: [new Paragraph({ text: "top to bottom" }), new Paragraph({})],
+                    textDirection: TextDirection.TOP_TO_BOTTOM_RIGHT_TO_LEFT,
                 }),
             ],
         }),

--- a/demo/31-tables.ts
+++ b/demo/31-tables.ts
@@ -1,7 +1,7 @@
 // Example of how you would create a table and add data to it
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { Document, HeadingLevel, Packer, Paragraph, Table, TableCell, TableRow, VerticalAlign } from "../build";
+import { Document, HeadingLevel, Packer, Paragraph, Table, TableCell, TableRow, VerticalAlign, TextDirection } from "../build";
 
 const doc = new Document();
 
@@ -16,6 +16,14 @@ const table = new Table({
                 new TableCell({
                     children: [new Paragraph({}), new Paragraph({})],
                     verticalAlign: VerticalAlign.CENTER,
+                }),
+                new TableCell({
+                    children: [new Paragraph({text: "bottom to top"}), new Paragraph({})],
+                    textDirection: TextDirection.BOTTOMTOTOPLEFTTORIGHT
+                }),
+                new TableCell({
+                    children: [new Paragraph({text: "top to bottom"}), new Paragraph({})],
+                    textDirection: TextDirection.TOPTOBOTTOMRIGHTTOLEFT
                 }),
             ],
         }),
@@ -34,6 +42,22 @@ const table = new Table({
                     children: [
                         new Paragraph({
                             text: "This text should be in the middle of the cell",
+                        }),
+                    ],
+                    verticalAlign: VerticalAlign.CENTER,
+                }),
+                new TableCell({
+                    children: [
+                        new Paragraph({
+                            text: "Text above should be vertical from bottom to top",
+                        }),
+                    ],
+                    verticalAlign: VerticalAlign.CENTER,
+                }),
+                new TableCell({
+                    children: [
+                        new Paragraph({
+                            text: "Text above should be vertical from top to bottom",
                         }),
                     ],
                     verticalAlign: VerticalAlign.CENTER,

--- a/src/file/table/table-cell/table-cell-components.ts
+++ b/src/file/table/table-cell/table-cell-components.ts
@@ -158,6 +158,31 @@ export class VAlign extends XmlComponent {
     }
 }
 
+export enum TextDirection {
+    BOTTOMTOTOPLEFTTORIGHT = "btLr",
+    LEFTTORIGHTTOPTOBOTTOM = "lrTb",
+    TOPTOBOTTOMRIGHTTOLEFT = "tbRl",
+}
+
+class TDirectionAttributes extends XmlAttributeComponent<{ readonly val: TextDirection }> {
+    protected readonly xmlKeys = { val: "w:val" };
+}
+
+/**
+ * Text Direction within a table cell
+ */
+export class TDirection extends XmlComponent {
+    constructor(value: TextDirection) {
+        super("w:textDirection");
+
+        this.root.push(
+            new TDirectionAttributes({
+                val: value,
+            }),
+        );
+    }
+}
+
 export enum WidthType {
     /** Auto. */
     AUTO = "auto",

--- a/src/file/table/table-cell/table-cell-components.ts
+++ b/src/file/table/table-cell/table-cell-components.ts
@@ -159,9 +159,9 @@ export class VAlign extends XmlComponent {
 }
 
 export enum TextDirection {
-    BOTTOMTOTOPLEFTTORIGHT = "btLr",
-    LEFTTORIGHTTOPTOBOTTOM = "lrTb",
-    TOPTOBOTTOMRIGHTTOLEFT = "tbRl",
+    BOTTOM_TO_TOP_LEFT_TO_RIGHT = "btLr",
+    LEFT_TO_RIGHT_TOP_TO_BOTTOM = "lrTb",
+    TOP_TO_BOTTOM_RIGHT_TO_LEFT = "tbRl",
 }
 
 class TDirectionAttributes extends XmlAttributeComponent<{ readonly val: TextDirection }> {

--- a/src/file/table/table-cell/table-cell-properties.ts
+++ b/src/file/table/table-cell/table-cell-properties.ts
@@ -6,6 +6,8 @@ import {
     GridSpan,
     TableCellBorders,
     TableCellWidth,
+    TDirection,
+    TextDirection,
     VAlign,
     VerticalAlign,
     VerticalMerge,
@@ -58,6 +60,12 @@ export class TableCellProperties extends IgnoreIfEmptyXmlComponent {
 
     public addMargins(options: ITableCellMarginOptions): TableCellProperties {
         this.root.push(new TableCellMargin(options));
+
+        return this;
+    }
+
+    public setTextDirection(type: TextDirection): TableCellProperties {
+        this.root.push(new TDirection(type));
 
         return this;
     }

--- a/src/file/table/table-cell/table-cell.spec.ts
+++ b/src/file/table/table-cell/table-cell.spec.ts
@@ -5,7 +5,7 @@ import { BorderStyle } from "file/styles";
 
 import { ShadingType } from "../shading";
 import { TableCell } from "./table-cell";
-import { TableCellBorders, TableCellWidth, VerticalAlign, VerticalMergeType, WidthType } from "./table-cell-components";
+import { TableCellBorders, TableCellWidth, TextDirection, VerticalAlign, VerticalMergeType, WidthType } from "./table-cell-components";
 
 describe("TableCellBorders", () => {
     describe("#prepForXml", () => {
@@ -259,6 +259,34 @@ describe("TableCell", () => {
                                 "w:vAlign": {
                                     _attr: {
                                         "w:val": "center",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "w:p": {},
+                    },
+                ],
+            });
+        });
+
+        it("should create with text direction", () => {
+            const cell = new TableCell({
+                children: [],
+                textDirection: TextDirection.BOTTOMTOTOPLEFTTORIGHT,
+            });
+
+            const tree = new Formatter().format(cell);
+
+            expect(tree).to.deep.equal({
+                "w:tc": [
+                    {
+                        "w:tcPr": [
+                            {
+                                "w:textDirection": {
+                                    _attr: {
+                                        "w:val": "btLr",
                                     },
                                 },
                             },

--- a/src/file/table/table-cell/table-cell.spec.ts
+++ b/src/file/table/table-cell/table-cell.spec.ts
@@ -274,7 +274,7 @@ describe("TableCell", () => {
         it("should create with text direction", () => {
             const cell = new TableCell({
                 children: [],
-                textDirection: TextDirection.BOTTOMTOTOPLEFTTORIGHT,
+                textDirection: TextDirection.BOTTOM_TO_TOP_LEFT_TO_RIGHT,
             });
 
             const tree = new Formatter().format(cell);

--- a/src/file/table/table-cell/table-cell.ts
+++ b/src/file/table/table-cell/table-cell.ts
@@ -7,13 +7,14 @@ import { File } from "../../file";
 import { ITableShadingAttributesProperties } from "../shading";
 import { Table } from "../table";
 import { ITableCellMarginOptions } from "./cell-margin/table-cell-margins";
-import { VerticalAlign, VerticalMergeType, WidthType } from "./table-cell-components";
+import { TextDirection, VerticalAlign, VerticalMergeType, WidthType } from "./table-cell-components";
 import { TableCellProperties } from "./table-cell-properties";
 
 export interface ITableCellOptions {
     readonly shading?: ITableShadingAttributesProperties;
     readonly margins?: ITableCellMarginOptions;
     readonly verticalAlign?: VerticalAlign;
+    readonly textDirection?: TextDirection;
     readonly verticalMerge?: VerticalMergeType;
     readonly width?: {
         readonly size: number | string;
@@ -61,6 +62,10 @@ export class TableCell extends XmlComponent {
 
         if (options.verticalAlign) {
             this.properties.setVerticalAlign(options.verticalAlign);
+        }
+
+        if (options.textDirection) {
+            this.properties.setTextDirection(options.textDirection);
         }
 
         if (options.verticalMerge) {


### PR DESCRIPTION
This adds _textDirection_ option to TableCell. There are three values for the _textDirection_ option (from the enumeration):

> BOTTOMTOTOPLEFTTORIGHT = "btLr",
> LEFTTORIGHTTOPTOBOTTOM = "lrTb",
> TOPTOBOTTOMRIGHTTOLEFT = "tbRl"

So, an example usage would look like this:
```
new TableCell({
    children: [new Paragraph({text: "top to bottom"}), new Paragraph({})],
    textDirection: TextDirection.TOPTOBOTTOMRIGHTTOLEFT
}),
```

Note that there are more options available from official [microsoft pages](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.textdirectionvalues?view=openxml-2.8.1). However, the ones not implemented end in _*2010_ and _*rotate_. I wasn't sure if version specific options should be supported or not. And the *rotate didn't seem to make any difference when I tested. Of course, if you feel they all should be supported, then I am ok with that.  Also, I just uppercased the options from MS official. It's ugly, but I was trying to remain consistent. 

I also added a test case, and updated the table demo (31).

Tested on MicroSoft Word 365
Node version: v12.14.0
