### PR TITLE
Add appendRun method to Paragraph class

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,7 +1,7 @@
 {
   "check-coverage": true,
   "lines": 93.53,
-  "functions": 89.63,
+  "functions": 89.62,
   "branches": 88.57,
   "statements": 93.34,
   "include": [

--- a/src/file/paragraph/paragraph.ts
+++ b/src/file/paragraph/paragraph.ts
@@ -171,6 +171,11 @@ export class Paragraph extends XmlComponent {
         return super.prepForXml();
     }
 
+    public appendRun(run: Run): Paragraph {
+        this.root.push(run);
+        return this;
+    }
+
     public addRunToFront(run: Run): Paragraph {
         this.root.splice(1, 0, run);
         return this;


### PR DESCRIPTION
There used to a method called `addRun` on the `Paragraph` class but it got removed in the 5.0.0 release. It was useful and IMO an unnecessary breaking change. I called it `appendRun` as that name implies that it will be the last child and the breaking change has already been made so I figured now is a good time to rename it.