### PR TITLE
Update table-row.ts to use correct height property

### DIFF
--- a/src/file/table/table-row/table-row.ts
+++ b/src/file/table/table-row/table-row.ts
@@ -34,7 +34,7 @@ export class TableRow extends XmlComponent {
         }
 
         if (options.height) {
-            this.properties.setHeight(options.height.height, options.height.rule);
+            this.properties.setHeight(options.height.value, options.height.rule);
         }
     }
 


### PR DESCRIPTION
the height property in table-row was set to height.height instead of height.value. This was then passing an undefined value to the setHeight function.

Corrected the issue above so the height property should work now.