### PR TITLE
table-row height correction

### DIFF
--- a/src/file/table/table-row/table-row-height.ts
+++ b/src/file/table/table-row/table-row-height.ts
@@ -10,12 +10,12 @@ export enum HeightRule {
 }
 
 interface ITableRowHeight {
-    readonly height: number;
+    readonly value: number;
     readonly rule: HeightRule;
 }
 
 export class TableRowHeightAttributes extends XmlAttributeComponent<ITableRowHeight> {
-    protected readonly xmlKeys = { height: "w:val", rule: "w:hRule" };
+    protected readonly xmlKeys = { value: "w:val", rule: "w:hRule" };
 }
 
 export class TableRowHeight extends XmlComponent {
@@ -24,7 +24,7 @@ export class TableRowHeight extends XmlComponent {
 
         this.root.push(
             new TableRowHeightAttributes({
-                height: value,
+                value: value,
                 rule: rule,
             }),
         );

--- a/src/file/table/table-row/table-row-properties.ts
+++ b/src/file/table/table-row/table-row-properties.ts
@@ -18,8 +18,8 @@ export class TableRowProperties extends IgnoreIfEmptyXmlComponent {
         return this;
     }
 
-    public setHeight(height: number, rule: HeightRule): TableRowProperties {
-        this.root.push(new TableRowHeight(height, rule));
+    public setHeight(value: number, rule: HeightRule): TableRowProperties {
+        this.root.push(new TableRowHeight(value, rule));
 
         return this;
     }

--- a/src/file/table/table-row/table-row.spec.ts
+++ b/src/file/table/table-row/table-row.spec.ts
@@ -92,7 +92,7 @@ describe("TableRow", () => {
             const tableRow = new TableRow({
                 children: [],
                 height: {
-                    height: 100,
+                    value: 100,
                     rule: HeightRule.EXACT,
                 },
             });

--- a/src/file/table/table-row/table-row.ts
+++ b/src/file/table/table-row/table-row.ts
@@ -7,7 +7,7 @@ export interface ITableRowOptions {
     readonly cantSplit?: boolean;
     readonly tableHeader?: boolean;
     readonly height?: {
-        readonly height: number;
+        readonly value: number;
         readonly rule: HeightRule;
     };
     readonly children: TableCell[];
@@ -34,7 +34,7 @@ export class TableRow extends XmlComponent {
         }
 
         if (options.height) {
-            this.properties.setHeight(options.height.height, options.height.rule);
+            this.properties.setHeight(options.height.value, options.height.rule);
         }
     }
 


### PR DESCRIPTION
resubmitting a pull request I sent on 15/07/2020. Cloned the project and followed the correct build procedure this time to hopefully ensure nothing bugs out when **dolanmiu** tries the build again.

Thought it best to convert instances of **height** to **value** as the xmlKey is mapping to **w:val** (which makes more sense to me) and the documentation refers to value as a property.
