### PR TITLE
feat: Add decimalFullWidth numbering type

### DIFF
--- a/src/file/document/body/section-properties/page-number/page-number.ts
+++ b/src/file/document/body/section-properties/page-number/page-number.ts
@@ -14,6 +14,7 @@ export enum PageNumberFormat {
     ORDINAL_TEXT = "ordinalText",
     UPPER_LETTER = "upperLetter",
     UPPER_ROMAN = "upperRoman",
+    DECIMAL_FULL_WIDTH = "decimalFullWidth",
 }
 
 export interface IPageNumberTypeAttributes {


### PR DESCRIPTION
I want to use fullwidth number for numbering like `１` `２` . (I'm Japanese native)
