### PR TITLE
remove broken examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Please refer to the [documentation at https://docx.js.org/](https://docx.js.org/
 
 # Examples
 
-Check the `examples` section in the [documentation](https://docx.js.org/#/examples) and the [demo folder](https://github.com/dolanmiu/docx/tree/master/demo) for examples.
+Check the [demo folder](https://github.com/dolanmiu/docx/tree/master/demo) for examples.
 
 # Contributing
 


### PR DESCRIPTION
Link in readme was broken.
New link in docs points to demo folder.

As such, linking directly to demos folder for examples.

Hope this helps!