### PR TITLE
add settings option to add trackRevisions

### DIFF
--- a/src/file/settings/settings.spec.ts
+++ b/src/file/settings/settings.spec.ts
@@ -79,4 +79,47 @@ describe("Settings", () => {
             expect(keys[0]).to.be.equal("w:compat");
         });
     });
+    describe("#addTrackRevisions", () => {
+        it("should add an empty Track Revisions", () => {
+            const settings = new Settings();
+            settings.addTrackRevisions();
+
+            const tree = new Formatter().format(settings);
+            let keys: string[] = Object.keys(tree);
+            expect(keys[0]).to.be.equal("w:settings");
+            const rootArray = tree["w:settings"];
+            expect(rootArray).is.an.instanceof(Array);
+            expect(rootArray).has.length(2);
+            keys = Object.keys(rootArray[0]);
+            expect(keys).is.an.instanceof(Array);
+            expect(keys).has.length(1);
+            expect(keys[0]).to.be.equal("_attr");
+            keys = Object.keys(rootArray[1]);
+            expect(keys).is.an.instanceof(Array);
+            expect(keys).has.length(1);
+            expect(keys[0]).to.be.equal("w:trackRevisions");
+        });
+    });
+    describe("#addTrackRevisionsTwice", () => {
+        it("should add an empty Track Revisions if called twice", () => {
+            const settings = new Settings();
+            settings.addTrackRevisions();
+            settings.addTrackRevisions();
+
+            const tree = new Formatter().format(settings);
+            let keys: string[] = Object.keys(tree);
+            expect(keys[0]).to.be.equal("w:settings");
+            const rootArray = tree["w:settings"];
+            expect(rootArray).is.an.instanceof(Array);
+            expect(rootArray).has.length(2);
+            keys = Object.keys(rootArray[0]);
+            expect(keys).is.an.instanceof(Array);
+            expect(keys).has.length(1);
+            expect(keys[0]).to.be.equal("_attr");
+            keys = Object.keys(rootArray[1]);
+            expect(keys).is.an.instanceof(Array);
+            expect(keys).has.length(1);
+            expect(keys[0]).to.be.equal("w:trackRevisions");
+        });
+    });
 });

--- a/src/file/settings/settings.ts
+++ b/src/file/settings/settings.ts
@@ -1,6 +1,7 @@
 import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
 import { Compatibility } from "./compatibility";
 import { UpdateFields } from "./update-fields";
+import { TrackRevisions } from "./track-revisions";
 
 export interface ISettingsAttributesProperties {
     readonly wpc?: string;
@@ -46,6 +47,7 @@ export class SettingsAttributes extends XmlAttributeComponent<ISettingsAttribute
 
 export class Settings extends XmlComponent {
     private readonly compatibility;
+    private readonly trackRevisions;
 
     constructor() {
         super("w:settings");
@@ -71,6 +73,7 @@ export class Settings extends XmlComponent {
             }),
         );
         this.compatibility = new Compatibility();
+        this.trackRevisions = new TrackRevisions();
     }
 
     public addUpdateFields(): void {
@@ -85,5 +88,13 @@ export class Settings extends XmlComponent {
         }
 
         return this.compatibility;
+    }
+
+    public addTrackRevisions(): TrackRevisions {
+        if (!this.root.find((child) => child instanceof TrackRevisions)) {
+            this.addChildElement(this.trackRevisions);
+        }
+
+        return this.trackRevisions;
     }
 }

--- a/src/file/settings/track-revisions.spec.ts
+++ b/src/file/settings/track-revisions.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from "chai";
+import { Formatter } from "export/formatter";
+import { TrackRevisions } from "file/settings/track-revisions";
+
+import { EMPTY_OBJECT } from "file/xml-components";
+
+describe("TrackRevisions", () => {
+    describe("#constructor", () => {
+        it("creates an initially empty property object", () => {
+            const trackRevisions = new TrackRevisions();
+
+            const tree = new Formatter().format(trackRevisions);
+            expect(tree).to.deep.equal({ "w:trackRevisions": EMPTY_OBJECT });
+        });
+    });
+});

--- a/src/file/settings/track-revisions.ts
+++ b/src/file/settings/track-revisions.ts
@@ -1,0 +1,7 @@
+import { XmlComponent } from "file/xml-components";
+
+export class TrackRevisions extends XmlComponent {
+    constructor() {
+        super("w:trackRevisions");
+    }
+}


### PR DESCRIPTION
This is a PR for issue #223 and basically a replacement for the open PR #224. Similar to the existing settings methods, it just adds a new empty element `w:trackRevisions`. I am not sure if the yes/ no value from the original PR adds any value, but apparently MS Word adds an empty element when the setting is toggled and otherwise it is omitted. Also a public methods is somehow cleaner than passing that value through various properties/ constructors (with the side effect that the existing unit tests do not need to be changed).

So, in a nutshell this PR adds the option to call,
```
doc.Settings.addTrackRevisions()
```
which has the following effect on the document.

<img width="1078" alt="Screenshot 2020-09-23 at 11 34 55" src="https://user-images.githubusercontent.com/5912220/93995064-d3dfd100-fd90-11ea-99b3-ebdd30c14052.png">
