### PR TITLE
Add defaultStyles option to overwrite the core default styles 

### DIFF
--- a/demo/11-declaritive-styles-2.ts
+++ b/demo/11-declaritive-styles-2.ts
@@ -17,55 +17,55 @@ import {
 } from "../build";
 
 const doc = new Document({
-    defaultStyles: {
-        heading1: {
-            run: {
-                font: "Calibri",
-                size: 52,
-                bold: true,
-                color: "000000",
-                underline: {
-                    type: UnderlineType.SINGLE,
+    styles: {
+        default: {
+            heading1: {
+                run: {
+                    font: "Calibri",
+                    size: 52,
+                    bold: true,
                     color: "000000",
+                    underline: {
+                        type: UnderlineType.SINGLE,
+                        color: "000000",
+                    },
+                },
+                paragraph: {
+                    alignment: AlignmentType.CENTER,
+                    spacing: { line: 340 },
                 },
             },
-            paragraph: {
-                alignment: AlignmentType.CENTER,
-                spacing: { line: 340 },
+            heading2: {
+                run: {
+                    font: "Calibri",
+                    size: 26,
+                    bold: true,
+                },
+                paragraph: {
+                    spacing: { line: 340 },
+                },
+            },
+            heading3: {
+                run: {
+                    font: "Calibri",
+                    size: 26,
+                    bold: true,
+                },
+                paragraph: {
+                    spacing: { line: 276 },
+                },
+            },
+            heading4: {
+                run: {
+                    font: "Calibri",
+                    size: 26,
+                    bold: true,
+                },
+                paragraph: {
+                    alignment: AlignmentType.JUSTIFIED,
+                },
             },
         },
-        heading2: {
-            run: {
-                font: "Calibri",
-                size: 26,
-                bold: true,
-            },
-            paragraph: {
-                spacing: { line: 340 },
-            },
-        },
-        heading3: {
-            run: {
-                font: "Calibri",
-                size: 26,
-                bold: true,
-            },
-            paragraph: {
-                spacing: { line: 276 },
-            },
-        },
-        heading4: {
-            run: {
-                font: "Calibri",
-                size: 26,
-                bold: true,
-            },
-            paragraph: {
-                alignment: AlignmentType.JUSTIFIED,
-            },
-        },
-    },
-    styles: {
         paragraphStyles: [
             {
                 id: "normalPara",

--- a/demo/11-declaritive-styles-2.ts
+++ b/demo/11-declaritive-styles-2.ts
@@ -17,74 +17,56 @@ import {
 } from "../build";
 
 const doc = new Document({
+    defaultStyles: {
+        heading1: {
+            run: {
+                font: "Calibri",
+                size: 52,
+                bold: true,
+                color: "000000",
+                underline: {
+                    type: UnderlineType.SINGLE,
+                    color: "000000",
+                },
+            },
+            paragraph: {
+                alignment: AlignmentType.CENTER,
+                spacing: { line: 340 },
+            },
+        },
+        heading2: {
+            run: {
+                font: "Calibri",
+                size: 26,
+                bold: true,
+            },
+            paragraph: {
+                spacing: { line: 340 },
+            },
+        },
+        heading3: {
+            run: {
+                font: "Calibri",
+                size: 26,
+                bold: true,
+            },
+            paragraph: {
+                spacing: { line: 276 },
+            },
+        },
+        heading4: {
+            run: {
+                font: "Calibri",
+                size: 26,
+                bold: true,
+            },
+            paragraph: {
+                alignment: AlignmentType.JUSTIFIED,
+            },
+        },
+    },
     styles: {
         paragraphStyles: [
-            {
-                id: "Heading1",
-                name: "Heading 1",
-                basedOn: "Normal",
-                next: "Normal",
-                quickFormat: true,
-                run: {
-                    font: "Calibri",
-                    size: 52,
-                    bold: true,
-                    color: "000000",
-                    underline: {
-                        type: UnderlineType.SINGLE,
-                        color: "000000",
-                    },
-                },
-                paragraph: {
-                    alignment: AlignmentType.CENTER,
-                    spacing: { line: 340 },
-                },
-            },
-            {
-                id: "Heading2",
-                name: "Heading 2",
-                basedOn: "Normal",
-                next: "Normal",
-                quickFormat: true,
-                run: {
-                    font: "Calibri",
-                    size: 26,
-                    bold: true,
-                },
-                paragraph: {
-                    spacing: { line: 340 },
-                },
-            },
-            {
-                id: "Heading3",
-                name: "Heading 3",
-                basedOn: "Normal",
-                next: "Normal",
-                quickFormat: true,
-                run: {
-                    font: "Calibri",
-                    size: 26,
-                    bold: true,
-                },
-                paragraph: {
-                    spacing: { line: 276 },
-                },
-            },
-            {
-                id: "Heading4",
-                name: "Heading 4",
-                basedOn: "Normal",
-                next: "Normal",
-                quickFormat: true,
-                run: {
-                    font: "Calibri",
-                    size: 26,
-                    bold: true,
-                },
-                paragraph: {
-                    alignment: AlignmentType.JUSTIFIED,
-                },
-            },
             {
                 id: "normalPara",
                 name: "Normal Para",
@@ -138,12 +120,6 @@ const doc = new Document({
                 paragraph: {
                     spacing: { line: 276, before: 20 * 72 * 0.1, after: 20 * 72 * 0.05 },
                 },
-            },
-            {
-                id: "ListParagraph",
-                name: "List Paragraph",
-                basedOn: "Normal",
-                quickFormat: true,
             },
         ],
     },

--- a/demo/2-declaritive-styles.ts
+++ b/demo/2-declaritive-styles.ts
@@ -7,47 +7,44 @@ const doc = new Document({
     creator: "Clippy",
     title: "Sample Document",
     description: "A brief example of using docx",
+    defaultStyles: {
+        heading1: {
+            run: {
+                size: 28,
+                bold: true,
+                italics: true,
+                color: "red",
+            },
+            paragraph: {
+                spacing: {
+                    after: 120,
+                },
+            },
+        },
+        heading2: {
+            run: {
+                size: 26,
+                bold: true,
+                underline: {
+                    type: UnderlineType.DOUBLE,
+                    color: "FF0000",
+                },
+            },
+            paragraph: {
+                spacing: {
+                    before: 240,
+                    after: 120,
+                },
+            },
+        },
+        listParagraph: {
+            run: {
+                color: '#FF0000'
+            }
+        }
+    },
     styles: {
         paragraphStyles: [
-            {
-                id: "Heading1",
-                name: "Heading 1",
-                basedOn: "Normal",
-                next: "Normal",
-                quickFormat: true,
-                run: {
-                    size: 28,
-                    bold: true,
-                    italics: true,
-                    color: "red",
-                },
-                paragraph: {
-                    spacing: {
-                        after: 120,
-                    },
-                },
-            },
-            {
-                id: "Heading2",
-                name: "Heading 2",
-                basedOn: "Normal",
-                next: "Normal",
-                quickFormat: true,
-                run: {
-                    size: 26,
-                    bold: true,
-                    underline: {
-                        type: UnderlineType.DOUBLE,
-                        color: "FF0000",
-                    },
-                },
-                paragraph: {
-                    spacing: {
-                        before: 240,
-                        after: 120,
-                    },
-                },
-            },
             {
                 id: "aside",
                 name: "Aside",
@@ -74,12 +71,6 @@ const doc = new Document({
                 paragraph: {
                     spacing: { line: 276, before: 20 * 72 * 0.1, after: 20 * 72 * 0.05 },
                 },
-            },
-            {
-                id: "ListParagraph",
-                name: "List Paragraph",
-                basedOn: "Normal",
-                quickFormat: true,
             },
         ],
     },

--- a/demo/2-declaritive-styles.ts
+++ b/demo/2-declaritive-styles.ts
@@ -7,43 +7,43 @@ const doc = new Document({
     creator: "Clippy",
     title: "Sample Document",
     description: "A brief example of using docx",
-    defaultStyles: {
-        heading1: {
-            run: {
-                size: 28,
-                bold: true,
-                italics: true,
-                color: "red",
-            },
-            paragraph: {
-                spacing: {
-                    after: 120,
-                },
-            },
-        },
-        heading2: {
-            run: {
-                size: 26,
-                bold: true,
-                underline: {
-                    type: UnderlineType.DOUBLE,
-                    color: "FF0000",
-                },
-            },
-            paragraph: {
-                spacing: {
-                    before: 240,
-                    after: 120,
-                },
-            },
-        },
-        listParagraph: {
-            run: {
-                color: '#FF0000'
-            }
-        }
-    },
     styles: {
+        default: {
+            heading1: {
+                run: {
+                    size: 28,
+                    bold: true,
+                    italics: true,
+                    color: "red",
+                },
+                paragraph: {
+                    spacing: {
+                        after: 120,
+                    },
+                },
+            },
+            heading2: {
+                run: {
+                    size: 26,
+                    bold: true,
+                    underline: {
+                        type: UnderlineType.DOUBLE,
+                        color: "FF0000",
+                    },
+                },
+                paragraph: {
+                    spacing: {
+                        before: 240,
+                        after: 120,
+                    },
+                },
+            },
+            listParagraph: {
+                run: {
+                    color: '#FF0000'
+                }
+            }
+        },
         paragraphStyles: [
             {
                 id: "aside",

--- a/src/file/core-properties/properties.ts
+++ b/src/file/core-properties/properties.ts
@@ -1,3 +1,4 @@
+import { IDefaultStylesOptions } from "docx/src/file/styles/factory";
 import { XmlComponent } from "file/xml-components";
 import { IDocumentBackgroundOptions } from "../document";
 
@@ -28,6 +29,7 @@ export interface IPropertiesOptions {
     readonly revision?: string;
     readonly externalStyles?: string;
     readonly styles?: IStylesOptions;
+    readonly defaultStyles?: IDefaultStylesOptions;
     readonly numbering?: INumberingOptions;
     readonly footnotes?: Paragraph[];
     readonly hyperlinks?: {

--- a/src/file/core-properties/properties.ts
+++ b/src/file/core-properties/properties.ts
@@ -1,4 +1,3 @@
-import { IDefaultStylesOptions } from "file/styles/factory";
 import { XmlComponent } from "file/xml-components";
 import { IDocumentBackgroundOptions } from "../document";
 
@@ -29,7 +28,6 @@ export interface IPropertiesOptions {
     readonly revision?: string;
     readonly externalStyles?: string;
     readonly styles?: IStylesOptions;
-    readonly defaultStyles?: IDefaultStylesOptions;
     readonly numbering?: INumberingOptions;
     readonly footnotes?: Paragraph[];
     readonly hyperlinks?: {

--- a/src/file/core-properties/properties.ts
+++ b/src/file/core-properties/properties.ts
@@ -1,4 +1,4 @@
-import { IDefaultStylesOptions } from "docx/src/file/styles/factory";
+import { IDefaultStylesOptions } from "file/styles/factory";
 import { XmlComponent } from "file/xml-components";
 import { IDocumentBackgroundOptions } from "../document";
 

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -106,14 +106,14 @@ export class File {
             this.styles = stylesFactory.newInstance(options.externalStyles);
         } else if (options.styles) {
             const stylesFactory = new DefaultStylesFactory();
-            const defaultStyles = stylesFactory.newInstance(options.defaultStyles);
+            const defaultStyles = stylesFactory.newInstance(options.styles.default);
             this.styles = new Styles({
                 ...defaultStyles,
                 ...options.styles,
             });
         } else {
             const stylesFactory = new DefaultStylesFactory();
-            this.styles = new Styles(stylesFactory.newInstance(options.defaultStyles));
+            this.styles = new Styles(stylesFactory.newInstance());
         }
 
         this.addDefaultRelationships();

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -106,14 +106,14 @@ export class File {
             this.styles = stylesFactory.newInstance(options.externalStyles);
         } else if (options.styles) {
             const stylesFactory = new DefaultStylesFactory();
-            const defaultStyles = stylesFactory.newInstance();
+            const defaultStyles = stylesFactory.newInstance(options.defaultStyles);
             this.styles = new Styles({
                 ...defaultStyles,
                 ...options.styles,
             });
         } else {
             const stylesFactory = new DefaultStylesFactory();
-            this.styles = new Styles(stylesFactory.newInstance());
+            this.styles = new Styles(stylesFactory.newInstance(options.defaultStyles));
         }
 
         this.addDefaultRelationships();

--- a/src/file/styles/factory.ts
+++ b/src/file/styles/factory.ts
@@ -1,7 +1,7 @@
 import { DocumentAttributes } from "../document/document-attributes";
 import { IStylesOptions } from "./styles";
 
-import { DocumentDefaults } from "./defaults";
+import { DocumentDefaults, IDocumentDefaultsOptions } from "./defaults";
 import {
     FootnoteReferenceStyle,
     FootnoteText,
@@ -13,12 +13,30 @@ import {
     Heading5Style,
     Heading6Style,
     HyperlinkStyle,
+    IBaseCharacterStyleOptions,
+    IBaseParagraphStyleOptions,
     ListParagraph,
     TitleStyle,
 } from "./style";
 
+export interface IDefaultStylesOptions {
+    readonly document?: IDocumentDefaultsOptions;
+    readonly title?: IBaseParagraphStyleOptions;
+    readonly heading1?: IBaseParagraphStyleOptions;
+    readonly heading2?: IBaseParagraphStyleOptions;
+    readonly heading3?: IBaseParagraphStyleOptions;
+    readonly heading4?: IBaseParagraphStyleOptions;
+    readonly heading5?: IBaseParagraphStyleOptions;
+    readonly heading6?: IBaseParagraphStyleOptions;
+    readonly listParagraph?: IBaseParagraphStyleOptions;
+    readonly hyperlink?: IBaseCharacterStyleOptions;
+    readonly footnoteReference?: IBaseCharacterStyleOptions;
+    readonly footnoteText?: IBaseParagraphStyleOptions;
+    readonly footnoteTextChar?: IBaseCharacterStyleOptions;
+}
+
 export class DefaultStylesFactory {
-    public newInstance(): IStylesOptions {
+    public newInstance(options: IDefaultStylesOptions = {}): IStylesOptions {
         const documentAttributes = new DocumentAttributes({
             mc: "http://schemas.openxmlformats.org/markup-compatibility/2006",
             r: "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
@@ -30,51 +48,58 @@ export class DefaultStylesFactory {
         return {
             initialStyles: documentAttributes,
             importedStyles: [
-                new DocumentDefaults(),
+                new DocumentDefaults(options.document),
                 new TitleStyle({
                     run: {
                         size: 56,
                     },
+                    ...options.title,
                 }),
                 new Heading1Style({
                     run: {
                         color: "2E74B5",
                         size: 32,
                     },
+                    ...options.heading1,
                 }),
                 new Heading2Style({
                     run: {
                         color: "2E74B5",
                         size: 26,
                     },
+                    ...options.heading2,
                 }),
                 new Heading3Style({
                     run: {
                         color: "1F4D78",
                         size: 24,
                     },
+                    ...options.heading3,
                 }),
                 new Heading4Style({
                     run: {
                         color: "2E74B5",
                         italics: true,
                     },
+                    ...options.heading4,
                 }),
                 new Heading5Style({
                     run: {
                         color: "2E74B5",
                     },
+                    ...options.heading5,
                 }),
                 new Heading6Style({
                     run: {
                         color: "1F4D78",
                     },
+                    ...options.heading6,
                 }),
-                new ListParagraph({}),
-                new HyperlinkStyle({}),
-                new FootnoteReferenceStyle({}),
-                new FootnoteText({}),
-                new FootnoteTextChar({}),
+                new ListParagraph(options.listParagraph || {}),
+                new HyperlinkStyle(options.hyperlink || {}),
+                new FootnoteReferenceStyle(options.footnoteReference || {}),
+                new FootnoteText(options.footnoteText || {}),
+                new FootnoteTextChar(options.footnoteTextChar || {}),
             ],
         };
     }

--- a/src/file/styles/styles.ts
+++ b/src/file/styles/styles.ts
@@ -1,11 +1,12 @@
+import { IDefaultStylesOptions } from "file/styles/factory";
 import { BaseXmlComponent, ImportedXmlComponent, XmlComponent } from "file/xml-components";
-
 import { StyleForCharacter, StyleForParagraph } from "./style";
 import { ICharacterStyleOptions } from "./style/character-style";
 import { IParagraphStyleOptions } from "./style/paragraph-style";
 export * from "./border";
 
 export interface IStylesOptions {
+    readonly default?: IDefaultStylesOptions;
     readonly initialStyles?: BaseXmlComponent;
     readonly paragraphStyles?: IParagraphStyleOptions[];
     readonly characterStyles?: ICharacterStyleOptions[];


### PR DESCRIPTION
This PR adds a `defaultStyles` option to the File options, which allows the base styles to be changed.

Overwriting the styles using the same names and IDs under `styles` option mostly works in Word/Office365, but it is buggy in other editors and often does not (free office, etc).

The declarative style demos were updated to use the new option.

Related tickets: #542 , #119 

Closes #542, #119 