### PR TITLE
Use LevelFormat string enum rather than strings

### DIFF
--- a/demo/2-declaritive-styles.ts
+++ b/demo/2-declaritive-styles.ts
@@ -1,7 +1,17 @@
 // Example on how to customise the look at feel using Styles
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { AlignmentType, convertInchesToTwip, Document, HeadingLevel, Packer, Paragraph, TextRun, UnderlineType } from "../build";
+import {
+    AlignmentType,
+    convertInchesToTwip,
+    Document,
+    HeadingLevel,
+    LevelFormat,
+    Packer,
+    Paragraph,
+    TextRun,
+    UnderlineType,
+} from "../build";
 
 const doc = new Document({
     creator: "Clippy",
@@ -81,7 +91,7 @@ const doc = new Document({
                 levels: [
                     {
                         level: 0,
-                        format: "lowerLetter",
+                        format: LevelFormat.LOWER_LETTER,
                         text: "%1)",
                         alignment: AlignmentType.LEFT,
                     },

--- a/demo/29-numbered-lists.ts
+++ b/demo/29-numbered-lists.ts
@@ -1,7 +1,7 @@
 // Numbered lists
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { AlignmentType, convertInchesToTwip, Document, Packer, Paragraph } from "../build";
+import { AlignmentType, convertInchesToTwip, Document, LevelFormat, Packer, Paragraph } from "../build";
 
 const doc = new Document({
     numbering: {
@@ -10,7 +10,7 @@ const doc = new Document({
                 levels: [
                     {
                         level: 0,
-                        format: "upperRoman",
+                        format: LevelFormat.UPPER_ROMAN,
                         text: "%1",
                         alignment: AlignmentType.START,
                         style: {
@@ -26,7 +26,7 @@ const doc = new Document({
                 levels: [
                     {
                         level: 0,
-                        format: "decimal",
+                        format: LevelFormat.DECIMAL,
                         text: "%1",
                         alignment: AlignmentType.START,
                         style: {
@@ -37,6 +37,22 @@ const doc = new Document({
                     },
                 ],
                 reference: "my-number-numbering-reference",
+            },
+            {
+                levels: [
+                    {
+                        level: 0,
+                        format: LevelFormat.DECIMAL_ZERO,
+                        text: "[%1]",
+                        alignment: AlignmentType.START,
+                        style: {
+                            paragraph: {
+                                indent: { left: convertInchesToTwip(0.5), hanging: convertInchesToTwip(0.18) },
+                            },
+                        },
+                    },
+                ],
+                reference: "padded-numbering-reference",
             },
         ],
     },
@@ -106,6 +122,139 @@ doc.addSection({
             text: "Step 3 - Put in oven",
             numbering: {
                 reference: "my-number-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
+                level: 0,
+            },
+        }),
+        new Paragraph({
+            text: "test",
+            numbering: {
+                reference: "padded-numbering-reference",
                 level: 0,
             },
         }),

--- a/demo/3-numbering-and-bullet-points.ts
+++ b/demo/3-numbering-and-bullet-points.ts
@@ -1,7 +1,7 @@
 // Numbering and bullet points example
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { AlignmentType, convertInchesToTwip, Document, Packer, Paragraph } from "../build";
+import { AlignmentType, convertInchesToTwip, Document, LevelFormat, Packer, Paragraph } from "../build";
 
 const doc = new Document({
     numbering: {
@@ -11,7 +11,7 @@ const doc = new Document({
                 levels: [
                     {
                         level: 0,
-                        format: "upperRoman",
+                        format: LevelFormat.UPPER_ROMAN,
                         text: "%1",
                         alignment: AlignmentType.START,
                         style: {
@@ -22,7 +22,7 @@ const doc = new Document({
                     },
                     {
                         level: 1,
-                        format: "decimal",
+                        format: LevelFormat.DECIMAL,
                         text: "%2.",
                         alignment: AlignmentType.START,
                         style: {
@@ -33,7 +33,7 @@ const doc = new Document({
                     },
                     {
                         level: 2,
-                        format: "lowerLetter",
+                        format: LevelFormat.LOWER_LETTER,
                         text: "%3)",
                         alignment: AlignmentType.START,
                         style: {
@@ -44,7 +44,7 @@ const doc = new Document({
                     },
                     {
                         level: 3,
-                        format: "upperLetter",
+                        format: LevelFormat.UPPER_LETTER,
                         text: "%4)",
                         alignment: AlignmentType.START,
                         style: {

--- a/demo/57-add-parent-numbered-lists.ts
+++ b/demo/57-add-parent-numbered-lists.ts
@@ -1,7 +1,7 @@
 // Numbered lists - Add parent number in sub number
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { AlignmentType, convertInchesToTwip, Document, HeadingLevel, Packer, Paragraph } from "../build";
+import { AlignmentType, convertInchesToTwip, Document, HeadingLevel, LevelFormat, Packer, Paragraph } from "../build";
 
 const doc = new Document({
     numbering: {
@@ -10,7 +10,7 @@ const doc = new Document({
                 levels: [
                     {
                         level: 0,
-                        format: "decimal",
+                        format: LevelFormat.DECIMAL,
                         text: "%1",
                         alignment: AlignmentType.START,
                         style: {
@@ -21,7 +21,7 @@ const doc = new Document({
                     },
                     {
                         level: 1,
-                        format: "decimal",
+                        format: LevelFormat.DECIMAL,
                         text: "%1.%2",
                         alignment: AlignmentType.START,
                         style: {

--- a/docs/usage/bullet-points.md
+++ b/docs/usage/bullet-points.md
@@ -9,7 +9,7 @@ const text = new TextRun("Bullet points");
 const paragraph = new Paragraph({
     text: "Bullet points",
     bullet: {
-        level: 0, // How deep you want the bullet to me
+        level: 0, //How deep you want the bullet to be
     },
 });
 ```

--- a/src/file/numbering/abstract-numbering.spec.ts
+++ b/src/file/numbering/abstract-numbering.spec.ts
@@ -7,7 +7,7 @@ import { AlignmentType, EmphasisMarkType, TabStopPosition } from "../paragraph";
 import { UnderlineType } from "../paragraph/run/underline";
 import { ShadingType } from "../table";
 import { AbstractNumbering } from "./abstract-numbering";
-import { LevelSuffix } from "./level";
+import { LevelFormat, LevelSuffix } from "./level";
 
 describe("AbstractNumbering", () => {
     it("stores its ID at its .id property", () => {
@@ -20,7 +20,7 @@ describe("AbstractNumbering", () => {
             const abstractNumbering = new AbstractNumbering(1, [
                 {
                     level: 3,
-                    format: "lowerLetter",
+                    format: LevelFormat.LOWER_LETTER,
                     text: "%1)",
                     alignment: AlignmentType.END,
                 },
@@ -29,7 +29,7 @@ describe("AbstractNumbering", () => {
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ _attr: { "w:ilvl": 3, "w15:tentative": 1 } });
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:start": { _attr: { "w:val": 1 } } });
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:lvlJc": { _attr: { "w:val": "end" } } });
-            expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:numFmt": { _attr: { "w:val": "lowerLetter" } } });
+            expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:numFmt": { _attr: { "w:val": LevelFormat.LOWER_LETTER } } });
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:lvlText": { _attr: { "w:val": "%1)" } } });
         });
 
@@ -37,7 +37,7 @@ describe("AbstractNumbering", () => {
             const abstractNumbering = new AbstractNumbering(1, [
                 {
                     level: 3,
-                    format: "lowerLetter",
+                    format: LevelFormat.LOWER_LETTER,
                     text: "%1)",
                 },
             ]);
@@ -45,7 +45,7 @@ describe("AbstractNumbering", () => {
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ _attr: { "w:ilvl": 3, "w15:tentative": 1 } });
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:start": { _attr: { "w:val": 1 } } });
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:lvlJc": { _attr: { "w:val": "start" } } });
-            expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:numFmt": { _attr: { "w:val": "lowerLetter" } } });
+            expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:numFmt": { _attr: { "w:val": LevelFormat.LOWER_LETTER } } });
             expect(tree["w:abstractNum"][2]["w:lvl"]).to.include({ "w:lvlText": { _attr: { "w:val": "%1)" } } });
         });
 
@@ -53,7 +53,7 @@ describe("AbstractNumbering", () => {
             const abstractNumbering = new AbstractNumbering(1, [
                 {
                     level: 3,
-                    format: "lowerLetter",
+                    format: LevelFormat.LOWER_LETTER,
                     text: "%1)",
                     alignment: AlignmentType.END,
                     suffix: LevelSuffix.SPACE,
@@ -68,7 +68,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -87,7 +87,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -106,7 +106,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -125,7 +125,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -144,7 +144,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -163,7 +163,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -182,7 +182,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -216,7 +216,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -239,7 +239,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -262,7 +262,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -281,7 +281,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             paragraph: {
@@ -324,7 +324,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: { size, sizeComplexScript },
@@ -340,7 +340,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -359,7 +359,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -378,7 +378,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -398,7 +398,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -417,7 +417,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -436,7 +436,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -455,7 +455,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -485,7 +485,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {
@@ -533,7 +533,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: { bold, boldComplexScript },
@@ -566,7 +566,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: { italics, italicsComplexScript },
@@ -604,7 +604,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: { highlight, highlightComplexScript },
@@ -682,7 +682,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: { shadow, shading, shadingComplexScript },
@@ -699,7 +699,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: {
@@ -718,7 +718,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: {
@@ -739,7 +739,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: {
@@ -763,7 +763,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: {
@@ -782,7 +782,7 @@ describe("AbstractNumbering", () => {
                     const abstractNumbering = new AbstractNumbering(1, [
                         {
                             level: 0,
-                            format: "lowerRoman",
+                            format: LevelFormat.LOWER_ROMAN,
                             text: "%0.",
                             style: {
                                 run: {
@@ -804,7 +804,7 @@ describe("AbstractNumbering", () => {
                 const abstractNumbering = new AbstractNumbering(1, [
                     {
                         level: 0,
-                        format: "lowerRoman",
+                        format: LevelFormat.LOWER_ROMAN,
                         text: "%0.",
                         style: {
                             run: {

--- a/src/file/numbering/level.ts
+++ b/src/file/numbering/level.ts
@@ -1,7 +1,25 @@
+// http://officeopenxml.com/WPnumbering-numFmt.php
 import { Attributes, XmlAttributeComponent, XmlComponent } from "file/xml-components";
 import { AlignmentType } from "../paragraph/formatting";
 import { IParagraphStylePropertiesOptions, ParagraphProperties } from "../paragraph/properties";
 import { IRunStylePropertiesOptions, RunProperties } from "../paragraph/run/properties";
+
+export enum LevelFormat {
+    BULLET = "bullet",
+    CARDINAL_TEXT = "cardinalText",
+    CHICAGO = "chicago",
+    DECIMAL = "decimal",
+    DECIMAL_ENCLOSED_CIRCLE = "decimalEnclosedCircle",
+    DECIMAL_ENCLOSED_FULLSTOP = "decimalEnclosedFullstop",
+    DECIMAL_ENCLOSED_PARENTHESES = "decimalEnclosedParen",
+    DECIMAL_ZERO = "decimalZero",
+    LOWER_LETTER = "lowerLetter",
+    LOWER_ROMAN = "lowerRoman",
+    NONE = "none",
+    ORDINAL_TEXT = "ordinalText",
+    UPPER_LETTER = "upperLetter",
+    UPPER_ROMAN = "upperRoman",
+}
 
 interface ILevelAttributesProperties {
     readonly ilvl?: number;
@@ -67,7 +85,7 @@ export enum LevelSuffix {
 
 export interface ILevelsOptions {
     readonly level: number;
-    readonly format?: string;
+    readonly format?: LevelFormat;
     readonly text?: string;
     readonly alignment?: AlignmentType;
     readonly start?: number;

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -5,7 +5,7 @@ import { IXmlableObject, XmlComponent } from "file/xml-components";
 
 import { DocumentAttributes } from "../document/document-attributes";
 import { AbstractNumbering } from "./abstract-numbering";
-import { ILevelsOptions } from "./level";
+import { ILevelsOptions, LevelFormat } from "./level";
 import { ConcreteNumbering } from "./num";
 
 export interface INumberingOptions {
@@ -51,7 +51,7 @@ export class Numbering extends XmlComponent {
         const abstractNumbering = this.createAbstractNumbering([
             {
                 level: 0,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CF",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -62,7 +62,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 1,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CB",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -73,7 +73,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 2,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25A0",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -84,7 +84,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 3,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CF",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -95,7 +95,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 4,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CB",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -106,7 +106,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 5,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25A0",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -117,7 +117,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 6,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CF",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -128,7 +128,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 7,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CF",
                 alignment: AlignmentType.LEFT,
                 style: {
@@ -139,7 +139,7 @@ export class Numbering extends XmlComponent {
             },
             {
                 level: 8,
-                format: "bullet",
+                format: LevelFormat.BULLET,
                 text: "\u25CF",
                 alignment: AlignmentType.LEFT,
                 style: {


### PR DESCRIPTION
Closes https://github.com/dolanmiu/docx/issues/518

Note: This should not be a breaking change as `string enums` and `strings` are identical, but you may get a compile error which can be easily fixed.