### PR TITLE
Added more data types for JSZip to consider using

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+end_of_line = lf
 
 [*.md]
 max_line_length = off

--- a/src/import-dotx/import-dotx.ts
+++ b/src/import-dotx/import-dotx.ts
@@ -46,7 +46,7 @@ export interface IDocumentTemplate {
 }
 
 export class ImportDotx {
-    public async extract(data: Buffer): Promise<IDocumentTemplate> {
+    public async extract(data: string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream): Promise<IDocumentTemplate> {
         const zipContent = await JSZip.loadAsync(data);
 
         const documentContent = await zipContent.files["word/document.xml"].async("text");

--- a/src/import-dotx/import-dotx.ts
+++ b/src/import-dotx/import-dotx.ts
@@ -46,7 +46,7 @@ export interface IDocumentTemplate {
 }
 
 export class ImportDotx {
-    public async extract(data: string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream): Promise<IDocumentTemplate> {
+    public async extract(data: Buffer | string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream): Promise<IDocumentTemplate> {
         const zipContent = await JSZip.loadAsync(data);
 
         const documentContent = await zipContent.files["word/document.xml"].async("text");

--- a/src/import-dotx/import-dotx.ts
+++ b/src/import-dotx/import-dotx.ts
@@ -46,7 +46,9 @@ export interface IDocumentTemplate {
 }
 
 export class ImportDotx {
-    public async extract(data: Buffer | string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream): Promise<IDocumentTemplate> {
+    public async extract(
+        data: Buffer | string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream,
+    ): Promise<IDocumentTemplate> {
         const zipContent = await JSZip.loadAsync(data);
 
         const documentContent = await zipContent.files["word/document.xml"].async("text");


### PR DESCRIPTION
JSZip supports more options.

I had an issue getting the pre-commit hook working with this too.

There will likely be updates for things other than just the "ImportDotx" function.