### PR TITLE
Allow styles and headings with numbering

### DIFF
--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -596,6 +596,36 @@ describe("Paragraph", () => {
             });
         });
 
+        it("should add a style to the list paragraph when provided", () => {
+            const paragraph = new Paragraph({
+                numbering: {
+                    reference: "test id",
+                    level: 0,
+                },
+                style: "myFancyStyle",
+            });
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.have.property("w:p").which.is.an("array").which.has.length.at.least(1);
+            expect(tree["w:p"][0]).to.have.property("w:pPr").which.is.an("array").which.has.length.at.least(1);
+            expect(tree["w:p"][0]["w:pPr"][0]).to.deep.equal({
+                "w:pStyle": { _attr: { "w:val": "myFancyStyle" } },
+            });
+        });
+
+        it("should not add ListParagraph style to a list when using custom numbering", () => {
+            const paragraph = new Paragraph({
+                numbering: {
+                    reference: "test id",
+                    level: 0,
+                    custom: true,
+                },
+            });
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.have.property("w:p").which.is.an("array").which.has.length.at.least(1);
+            expect(tree["w:p"][0]).to.have.property("w:pPr").which.is.an("array").which.has.length.at.least(1);
+            expect(tree["w:p"][0]["w:pPr"][0]).to.not.have.property("w:pStyle");
+        });
+
         it("it should add numbered properties", () => {
             const paragraph = new Paragraph({
                 numbering: {

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -126,9 +126,9 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
 
         if (options.numbering) {
             if (!options.style && !options.heading) {
-              if (!options.numbering.custom) {
-                this.push(new Style("ListParagraph"));
-              }
+                if (!options.numbering.custom) {
+                    this.push(new Style("ListParagraph"));
+                }
             }
             this.push(new NumberProperties(options.numbering.reference, options.numbering.level));
         }

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -125,8 +125,10 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
         }
 
         if (options.numbering) {
-            if (!options.numbering.custom) {
+            if(!options.style && !options.heading) {
+              if (!options.numbering.custom) {
                 this.push(new Style("ListParagraph"));
+              }
             }
             this.push(new NumberProperties(options.numbering.reference, options.numbering.level));
         }

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -125,7 +125,7 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
         }
 
         if (options.numbering) {
-            if(!options.style && !options.heading) {
+            if (!options.style && !options.heading) {
               if (!options.numbering.custom) {
                 this.push(new Style("ListParagraph"));
               }


### PR DESCRIPTION
This allows for paragraphs to have numbering and not loose the ability to apply styles or headings, but still falls back to the default ListParagraph style for backwards compatibility. It addresses #612 and implements the change suggested there by @hjj1227.

Closes #612