### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/usage/bullet-points.md
+++ b/docs/usage/bullet-points.md
@@ -5,12 +5,21 @@
 To make a bullet point, simply make a paragraph into a bullet point:
 
 ```ts
-const text = new TextRun("Bullet points");
-const paragraph = new Paragraph({
-    text: "Bullet points",
-    bullet: {
-        level: 0, //How deep you want the bullet to be
-    },
+doc.addSection({
+    children: [
+        new Paragraph({
+            text: "Bullet points",
+            bullet: {
+            level: 0 //How deep you want the bullet to be
+          }
+        }),
+        new Paragraph({
+            text: "Are awesome",
+            bullet: {
+            level: 0
+          }
+        })
+    ],
 });
 ```
 


### PR DESCRIPTION
The example suppose to produce 2 bullets 