### PR TITLE
Fix footer import

### DIFF
--- a/src/file/document-wrapper.ts
+++ b/src/file/document-wrapper.ts
@@ -1,5 +1,5 @@
 import { Document, IDocumentOptions } from "./document";
-import { Footer } from "./footer";
+import { Footer } from "./footer/footer";
 import { FootNotes } from "./footnotes";
 import { Header } from "./header/header";
 import { Relationships } from "./relationships";


### PR DESCRIPTION
This makes the footer import consistent with the header import, and fixes the compilation issue described in #843. Seems like a trivial fix, but I would appreciate a release for this as it's blocking me upgrading to docx v6.