### PR TITLE
Fixed typos in usage documentation

### DIFF
--- a/docs/usage/change-tracking.md
+++ b/docs/usage/change-tracking.md
@@ -27,7 +27,7 @@ const paragraph = new Paragraph({
 });
 ```
 
-Note that for a `InsertedTextRun` and `DeletedTextRun`, it is not possible to simply call it with only a text as in `new TextRun("some text")`, since the additonal fields for change tracking need to be provided. Similar to a normal `TextRun` you can add additional text properties.
+Note that for a `InsertedTextRun` and `DeletedTextRun`, it is not possible to simply call it with only a text as in `new TextRun("some text")`, since the additional fields for change tracking need to be provided. Similar to a normal `TextRun` you can add additional text properties.
 
 ```ts
 import { Paragraph, TextRun, InsertedTextRun, DeletedTextRun } from "docx";
@@ -48,7 +48,7 @@ const paragraph = new Paragraph({
 });
 ```
 
-In addtion to marking text as inserted or deleted, change tracking can also be added via the document settings. This will enable new changes to be tracked as well.
+In addition to marking text as inserted or deleted, change tracking can also be added via the document settings. This will enable new changes to be tracked as well.
 
 ```ts
 import { Document } from "docx";

--- a/docs/usage/images.md
+++ b/docs/usage/images.md
@@ -78,7 +78,7 @@ const doc = new Document({
 
 > Positioning is the method on how to place the image on the document
 
-![Word Image Positiong](https://user-images.githubusercontent.com/34742290/41765548-b0946302-7604-11e8-96f9-166a9f0b8f39.png)
+![Word Image Positioning](https://user-images.githubusercontent.com/34742290/41765548-b0946302-7604-11e8-96f9-166a9f0b8f39.png)
 
 Three types of image positioning is supported:
 
@@ -89,7 +89,7 @@ By default, images are exported as `Inline` elements.
 
 ### Usage
 
-Pass `options` into the `[POSITION_OPTIONS]` metioned in the [Intro above](#Intro).
+Pass `options` into the `[POSITION_OPTIONS]` mentioned in the [Intro above](#Intro).
 
 ## Floating
 

--- a/docs/usage/math.md
+++ b/docs/usage/math.md
@@ -6,7 +6,7 @@
 
 1.  To add math, create a `Math` object
 2.  Add `MathComponents` inside `Math`
-3.  `MathComponents` can have nested `MathComponents` inside. e.g. A fraction where the numerator is a square root, and the demoninator as another fraction. More on `MathComponents` below
+3.  `MathComponents` can have nested `MathComponents` inside. e.g. A fraction where the numerator is a square root, and the denominator as another fraction. More on `MathComponents` below
 4.  Make sure to add the `Math` object inside a `Paragraph`
 
 ## Example
@@ -61,7 +61,7 @@ new Math({
 
 ### Math Fraction
 
-`MathFractions` require a `numerator` and a `demoninator`, which are both a list of `MathComponents`
+`MathFractions` require a `numerator` and a `denominator`, which are both a list of `MathComponents`
 
 #### Example
 

--- a/docs/usage/numbering.md
+++ b/docs/usage/numbering.md
@@ -23,7 +23,7 @@ those bullets/numbering. An abstract numbering system defines how
 bullets/numbers are to be shown for lists, including any sublists that
 may be used. Thus each abstract definition includes a series of
 _levels_ which form a sequence starting at 0 indicating the top-level
-list look and increasing from there to descibe the sublists, then
+list look and increasing from there to describe the sublists, then
 sub-sublists, etc. Each level includes the following properties:
 
 *   **level**: This is its 0-based index in the definition stack
@@ -39,10 +39,10 @@ sub-sublists, etc. Each level includes the following properties:
     the sequence "a)", "b)", ...
 *   and a few others, which you can see in the OXML spec section 17.9.6
 
-## Document-level bullets/numbering defintions (concrete)
+## Document-level bullets/numbering definitions (concrete)
 
 Concrete definitions are sort of like concrete subclasses of the
-abstract defintions. They indicate their parent and are allowed to
+abstract definitions. They indicate their parent and are allowed to
 override certain level definitions. Thus two lists that differ only in
 how sub-sub-lists are to be displayed can share the same abstract
 numbering definition and have slightly different concrete definitions.

--- a/docs/usage/paragraph.md
+++ b/docs/usage/paragraph.md
@@ -1,6 +1,6 @@
 # Paragraph
 
-> Everything (text, images, graphs etc) in OpenXML is organised in paragraphs.
+> Everything (text, images, graphs etc) in OpenXML is organized in paragraphs.
 
 !> Paragraphs requires an understanding of [Sections](sections.md).
 
@@ -42,7 +42,7 @@ const doc = new Document({
 });
 ```
 
-Or the preferred convension, define the paragraph inside the section and remove the usage of variables:
+Or the preferred convention, define the paragraph inside the section and remove the usage of variables:
 
 ```ts
 const doc = new Document({

--- a/docs/usage/styling-with-xml.md
+++ b/docs/usage/styling-with-xml.md
@@ -3,7 +3,7 @@
 ## Setup
 
 1.  Create a new word document in Microsoft Word
-2.  Customise the styles on the Ribbon Bar.
+2.  Customize the styles on the Ribbon Bar.
     For example, modify the `Normal`, `Heading 1`, `Heading 2` like so:
 
     ![image](https://user-images.githubusercontent.com/2917613/41195113-65edebfa-6c1f-11e8-97b4-77de2d60044a.png)

--- a/docs/usage/table-of-contents.md
+++ b/docs/usage/table-of-contents.md
@@ -2,7 +2,7 @@
 
 You can generate table of contents with `docx`. More information can be found [here](http://officeopenxml.com/WPtableOfContents.php).
 
-> Tables of Contents are fields and, by design, it's content is only generated or updated by Word. We can't do it programatically.
+> Tables of Contents are fields and, by design, it's content is only generated or updated by Word. We can't do it programmatically.
 > This is why, when you open a the file, Word you will prompt the message "This document contains fields that may refer to other files. Do you want to update the fields in this document?".
 > You have say yes to Word generate the content of all table of contents.
 

--- a/docs/usage/tables.md
+++ b/docs/usage/tables.md
@@ -6,7 +6,7 @@
 
 -   `Tables` contain a list of `Rows`
 -   `Rows` contain a list of `TableCells`
--   `TableCells` contain a list of `Parahraphs` and/or `Tables`. You can add `Tables` as tables can be nested inside each other
+-   `TableCells` contain a list of `Paragraphs` and/or `Tables`. You can add `Tables` as tables can be nested inside each other
 
 Create a simple table like so:
 
@@ -346,7 +346,7 @@ _Source: https://github.com/dolanmiu/docx/blob/master/demo/4-basic-table.ts_
 
 ### Custom borders
 
-Example showing how to add colourful borders to tables
+Example showing how to add colorful borders to tables
 
 [Example](https://raw.githubusercontent.com/dolanmiu/docx/master/demo/20-table-cell-borders.ts ':include')
 


### PR DESCRIPTION
Hi Dolan!
Thanks for the great lib :)
I was reading usage docs and noticed some typos