### PR TITLE
Fixes #877: table columns defaulting to small/unusable sizes in some word processors

### DIFF
--- a/src/file/table/table.spec.ts
+++ b/src/file/table/table.spec.ts
@@ -178,9 +178,6 @@ describe("Table", () => {
             expect(tree).to.deep.equal({
                 "w:tbl": [
                     { "w:tblPr": [DEFAULT_TABLE_PROPERTIES, BORDERS, WIDTHS] },
-                    {
-                        "w:tblGrid": [{ "w:gridCol": { _attr: { "w:w": 100 } } }, { "w:gridCol": { _attr: { "w:w": 100 } } }],
-                    },
                     { "w:tr": [cell, cell] },
                     { "w:tr": [cell, cell] },
                     { "w:tr": [cell, cell] },
@@ -225,9 +222,6 @@ describe("Table", () => {
                 "w:tbl": [
                     { "w:tblPr": [DEFAULT_TABLE_PROPERTIES, BORDERS, WIDTHS] },
                     {
-                        "w:tblGrid": [{ "w:gridCol": { _attr: { "w:w": 100 } } }, { "w:gridCol": { _attr: { "w:w": 100 } } }],
-                    },
-                    {
                         "w:tr": [
                             {
                                 "w:tc": [{ "w:tcPr": [{ "w:gridSpan": { _attr: { "w:val": 2 } } }] }, cellP],
@@ -249,6 +243,37 @@ describe("Table", () => {
                             },
                             { "w:tc": [cellP] },
                         ],
+                    },
+                ],
+            });
+        });
+
+        it("creates a table explicit columnWidths", () => {
+            const table = new Table({
+                columnWidths: [200, 400],
+                rows: [
+                    new TableRow({
+                        children: [
+                            new TableCell({
+                                children: [new Paragraph("hello")],
+                            }),
+                            new TableCell({
+                                children: [new Paragraph("hello")],
+                            }),
+                        ],
+                    }),
+                ],
+            });
+            const tree = new Formatter().format(table);
+            const cellP = { "w:p": [{ "w:r": [{ "w:t": [{ _attr: { "xml:space": "preserve" } }, "hello"] }] }] };
+            expect(tree).to.deep.equal({
+                "w:tbl": [
+                    { "w:tblPr": [DEFAULT_TABLE_PROPERTIES, BORDERS, WIDTHS] },
+                    {
+                        "w:tblGrid": [{ "w:gridCol": { _attr: { "w:w": 200 } } }, { "w:gridCol": { _attr: { "w:w": 400 } } }],
+                    },
+                    {
+                        "w:tr": [{ "w:tc": [cellP] }, { "w:tc": [cellP] }],
                     },
                 ],
             });

--- a/src/file/table/table.ts
+++ b/src/file/table/table.ts
@@ -44,7 +44,7 @@ export class Table extends XmlComponent {
     constructor({
         rows,
         width,
-        columnWidths = Array<number>(Math.max(...rows.map((row) => row.CellCount))).fill(100),
+        columnWidths,
         margins: { marginUnitType, top, bottom, right, left } = { marginUnitType: WidthType.AUTO, top: 0, bottom: 0, right: 0, left: 0 },
         float,
         layout,
@@ -85,7 +85,9 @@ export class Table extends XmlComponent {
             }),
         );
 
-        this.root.push(new TableGrid(columnWidths));
+        if (columnWidths) {
+            this.root.push(new TableGrid(columnWidths));
+        }
 
         for (const row of rows) {
             this.root.push(row);


### PR DESCRIPTION
Fixes #877 - don't add `w:tblGrid` to table when `columnWidths` argument isn't provided. Fixed the Table tests to account for this, and added one additional test with `columnWidths` set to make sure it's added in that case.