### PR TITLE
Updates and fixes for documentation

### DIFF
--- a/docs/usage/bullet-points.md
+++ b/docs/usage/bullet-points.md
@@ -12,14 +12,14 @@ const doc = new Document({
             new Paragraph({
                 text: "Bullet points",
                 bullet: {
-                level: 0 //How deep you want the bullet to be
-            }
+                    level: 0 //How deep you want the bullet to be
+                }
             }),
             new Paragraph({
                 text: "Are awesome",
                 bullet: {
-                level: 0
-            }
+                    level: 0
+                }
             })
         ],
     }];

--- a/docs/usage/page-numbers.md
+++ b/docs/usage/page-numbers.md
@@ -5,35 +5,49 @@
 ?> **Note:** This feature only works on Headers and Footers
 
 ```ts
-doc.Header.createParagraph().addRun(new TextRun("Page Number: ").pageNumber()).addRun(new TextRun("to ").numberOfTotalPages());
+new Paragraph({
+    children: [
+        new TextRun({
+            children: ["Page #: ", PageNumber.CURRENT],
+        })
+    ]
+})
 ```
 
 ## Current page number
 
-To get the current page number, call the `.pageNumber()` method on a `TextRun`. Then add the newly created `TextRun` into a paragraph
-
 ```ts
-pageNumber();
+PageNumber.CURRENT
 ```
 
 For example:
 
 ```ts
-const currentPageRun = new TextRun("Current Page Number: ").pageNumber();
-paragraph.addRun(currentPageRun);
+new Paragraph({
+    children: [
+        new TextRun({
+            children: ["Page Number ", PageNumber.CURRENT],
+        })
+    ]
+})
 ```
 
 ## Total number of pages
 
 ```ts
-numberOfTotalPages();
+PageNumber.TOTAL_PAGES
 ```
 
 For example:
 
 ```ts
-const lastPage = new TextRun("Total Page Number: ").numberOfTotalPages();
-paragraph.addRun(lastPage);
+new Paragraph({
+    children: [
+        new TextRun({
+            children: ["Total Pages Number: ", PageNumber.TOTAL_PAGES],
+        })
+    ]
+})
 ```
 
 
@@ -42,17 +56,14 @@ paragraph.addRun(lastPage);
 You can combine the two to get "Page 2 of 10" effect:
 
 ```ts
-const currentPageRun = new TextRun("Page ").pageNumber();
-const lastPage = new TextRun("of ").numberOfTotalPages();
-
-paragraph.addRun(currentPageRun);
-paragraph.addRun(lastPage);
-```
-
-Or:
-
-```ts
-doc.Header.createParagraph().addRun(new TextRun("Page ").pageNumber()).addRun(new TextRun("of ").numberOfTotalPages());
+new Paragraph({
+    children: [
+        new TextRun("My awesome text here for my university dissertation. ")
+        new TextRun({
+            children: ["Page ", PageNumber.CURRENT, " of ", PageNumber.TOTAL_PAGES],
+        })
+    ]
+})
 ```
 
 ## Examples

--- a/docs/usage/paragraph.md
+++ b/docs/usage/paragraph.md
@@ -2,7 +2,7 @@
 
 > Everything (text, images, graphs etc) in OpenXML is organized in paragraphs.
 
-!> Paragraphs requires an understanding of [Sections](sections.md).
+!> Paragraphs requires an understanding of [Sections](usage/sections.md).
 
 You can create `Paragraphs` in the following ways:
 
@@ -16,7 +16,7 @@ const paragraph = new Paragraph("Short hand Hello World");
 
 ### Children Method
 
-This method is useful for adding different [text](text.md) with different styles, [symbols](symbols.md), or adding [images](images.md) inline.
+This method is useful for adding different [text](usage/text.md) with different styles, [symbols](usage/symbols.md), or adding [images](usage/images.md) inline.
 
 ```ts
 const paragraph = new Paragraph({

--- a/docs/usage/symbols.md
+++ b/docs/usage/symbols.md
@@ -1,8 +1,8 @@
 # Symbol Runs
 
-!> SymbolRuns require an understanding of [Paragraphs](paragraph.md).
+!> SymbolRuns require an understanding of [Paragraphs](usage/paragraph.md).
 
-You can add multiple `symbol runs` in `Paragraphs` along with [text runs](text.md) using the Paragraph's `children` property.
+You can add multiple `symbol runs` in `Paragraphs` along with [text runs](usage/text.md) using the Paragraph's `children` property.
 
 ```ts
 import { Paragraph, TextRun, SymbolRun } from "docx";
@@ -50,4 +50,4 @@ const symbol = new SymbolRun({
 });
 ```
 
-See the [text run](text.md) documentation for more info.
+See the [text run](usage/text.md) documentation for more info.

--- a/docs/usage/tables.md
+++ b/docs/usage/tables.md
@@ -237,12 +237,6 @@ const cell = new TableCell({
 | NIL      | is considered as zero             |
 | PCT      | percent of table width            |
 
-#### Example
-
-```ts
-cell.Properties.setWidth(100, WidthType.DXA);
-```
-
 ### Nested Tables
 
 To have a table within a table, simply add it in the `children` block of a `table cell`:


### PR DESCRIPTION
This PR fixes a couple issues with the docs:

- Broken links on Paragraph and Symbol pages
- Outdated examples showing the old method calling API