### PR TITLE
Numbering start from number doesn't work fix

### DIFF
--- a/demo/68-numbering-instances-and-starting-number.ts
+++ b/demo/68-numbering-instances-and-starting-number.ts
@@ -1,0 +1,86 @@
+import * as fs from "fs";
+import { Document, Packer, Paragraph, PageNumberFormat} from "../build";
+
+const doc = new Document({
+  numbering:{
+    config:[
+      {
+        reference: 'ref1',
+        levels: [
+          {
+            level: 0,
+            format: PageNumberFormat.DECIMAL,
+            text: '%1',
+            start: 10,
+          }
+        ],
+      },
+      {
+        reference: 'ref2',
+        levels: [
+          {
+            level: 0,
+            format: PageNumberFormat.DECIMAL,
+            text: '%1'
+          }
+        ],
+      },
+    ]
+  },
+  sections: [{
+    children: [
+      new Paragraph({
+        text: "REF1 - inst:0 - lvl:0",
+        numbering : {
+          reference: 'ref1',
+          instance: 0,
+          level: 0,
+        }
+      }),
+      new Paragraph({
+        text: "REF1 - inst:0 - lvl:0",
+        numbering : {
+          reference: 'ref1',
+          instance: 0,
+          level: 0,
+        }
+      }),
+      new Paragraph({
+        text: "REF1 - inst:1 - lvl:0",
+        numbering : {
+          reference: 'ref1',
+          instance: 1,
+          level: 0,
+        },
+      }),
+      new Paragraph({
+        text: "REF1 - inst:1 - lvl:0",
+        numbering : {
+          reference: 'ref1',
+          instance: 1,
+          level: 0,
+        }
+      }),
+      new Paragraph({
+        text: "REF2 - inst:0 - lvl:0",
+        numbering : {
+          reference: 'ref2',
+          instance: 1,
+          level: 0,
+        }
+      }),
+      new Paragraph({
+        text: "REF2 - inst:0 - lvl:0",
+        numbering : {
+          reference: 'ref2',
+          instance: 1,
+          level: 0,
+        }
+      })
+    ],
+  }]
+});
+
+Packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});

--- a/src/file/numbering/numbering.spec.ts
+++ b/src/file/numbering/numbering.spec.ts
@@ -112,5 +112,26 @@ describe("Numbering", () => {
                 expect(numbering.ConcreteNumbering).to.have.length(2);
             });
         });
+        describe("#referenceConfigMap", () => {
+            it("should store level configs into referenceConfigMap", () => {
+                const numbering = new Numbering({
+                    config: [
+                        {
+                            reference: "test-reference",
+                            levels: [
+                                {
+                                    level: 0,
+                                    start: 10,
+                                },
+                            ],
+                        },
+                    ],
+                });
+                numbering.createConcreteNumberingInstance("test-reference", 0);
+                const referenceConfig = numbering.ReferenceConfig[0];
+                const zeroLevelConfig = referenceConfig[0];
+                expect(zeroLevelConfig.start).to.be.equal(10);
+            });
+        });
     });
 });

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -215,8 +215,8 @@ export class Numbering extends XmlComponent {
         };
 
         const referenceConfigLevels = this.referenceConfigMap.get(reference);
-        const firstLevelStartNumber = referenceConfigLevels?.[0]?.start;
-        if (firstLevelStartNumber) {
+        const firstLevelStartNumber = referenceConfigLevels && referenceConfigLevels[0].start;
+        if (firstLevelStartNumber && Number.isInteger(firstLevelStartNumber)) {
             concreteNumberingSettings.overrideLevel = {
                 num: 0,
                 start: firstLevelStartNumber,

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -229,4 +229,7 @@ export class Numbering extends XmlComponent {
     public get ConcreteNumbering(): ConcreteNumbering[] {
         return Array.from(this.concreteNumberingMap.values());
     }
+    public get ReferenceConfig(): object[] {
+        return Array.from(this.referenceConfigMap.values());
+    }
 }

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -29,7 +29,7 @@ export interface INumberingOptions {
 export class Numbering extends XmlComponent {
     private readonly abstractNumberingMap = new Map<string, AbstractNumbering>();
     private readonly concreteNumberingMap = new Map<string, ConcreteNumbering>();
-    private readonly referenceConfigMap = new Map<string, ILevelsOptions>();
+    private readonly referenceConfigMap = new Map<string, object>();
 
     constructor(options: INumberingOptions) {
         super("w:numbering");
@@ -208,6 +208,10 @@ export class Numbering extends XmlComponent {
             abstractNumId: abstractNumbering.id,
             reference,
             instance,
+            overrideLevel: {
+                num: 0,
+                start: 1,
+            },
         };
 
         const referenceConfigLevels = this.referenceConfigMap.get(reference);
@@ -216,11 +220,6 @@ export class Numbering extends XmlComponent {
             concreteNumberingSettings.overrideLevel = {
                 num: 0,
                 start: firstLevelStartNumber,
-            };
-        } else {
-            concreteNumberingSettings.overrideLevel = {
-                num: 0,
-                start: 1,
             };
         }
 


### PR DESCRIPTION
Use level.start for overrideLevel.start if possible.
Implemented via additional reference config map.