### PR TITLE
Allow any `ParagraphChild` in `Bookmark`s

### DIFF
--- a/src/file/paragraph/links/bookmark.ts
+++ b/src/file/paragraph/links/bookmark.ts
@@ -2,15 +2,15 @@
 import { uniqueId } from "convenience-functions";
 import { XmlComponent } from "file/xml-components";
 
-import { TextRun } from "../run";
+import { ParagraphChild } from "../paragraph";
 import { BookmarkEndAttributes, BookmarkStartAttributes } from "./bookmark-attributes";
 
 export class Bookmark {
     public readonly start: BookmarkStart;
-    public readonly children: TextRun[];
+    public readonly children: ParagraphChild[];
     public readonly end: BookmarkEnd;
 
-    constructor(options: { readonly id: string; readonly children: TextRun[] }) {
+    constructor(options: { readonly id: string; readonly children: ParagraphChild[] }) {
         const linkId = uniqueId();
 
         this.start = new BookmarkStart(options.id, linkId);


### PR DESCRIPTION
This is a very minor change in types, I got there by adding other things into bookmarks. I am not sure if the typing is quite right, but this fixes type-bugs like:

![image](https://user-images.githubusercontent.com/913249/131723538-a6939d87-5f47-4f3a-b0c3-8e5044066077.png)

Let me know if (and where) to do digging on what is actually allowed to be in a bookmark. I have put it to `ParagraphChild` as the children of a bookmark in this PR.