### PR TITLE
Attaching numbering to custom style

### DIFF
--- a/demo/11-declaritive-styles-2.ts
+++ b/demo/11-declaritive-styles-2.ts
@@ -15,6 +15,7 @@ import {
     TableRow,
     TabStopPosition,
     UnderlineType,
+    LevelFormat,
 } from "../build";
 
 const table = new Table({
@@ -51,6 +52,19 @@ const table = new Table({
 });
 
 const doc = new Document({
+    numbering:{
+        config:[{
+            reference: 'ref1',
+            levels: [
+            {
+                level: 0,
+                format: LevelFormat.DECIMAL,
+                text: '%1)',
+                start: 50,
+            }
+            ],
+        }]
+    },
     styles: {
         default: {
             heading1: {
@@ -153,6 +167,28 @@ const doc = new Document({
                 basedOn: "Normal",
                 paragraph: {
                     spacing: { line: 276, before: 20 * 72 * 0.1, after: 20 * 72 * 0.05 },
+                },
+            },
+            {
+                id: "numberedPara",
+                name: "Numbered Para",
+                basedOn: "Normal",
+                next: "Normal",
+                quickFormat: true,
+                run: {
+                    font: "Calibri",
+                    size: 26,
+                    bold: true,
+                },
+                paragraph: {
+                    spacing: { line: 276, before: 20 * 72 * 0.1, after: 20 * 72 * 0.05 },
+                    rightTabStop: TabStopPosition.MAX,
+                    leftTabStop: 453.543307087,
+                    numbering : {
+                        reference: 'ref1',
+                        instance: 0,
+                        level: 0,
+                    }
                 },
             },
         ],
@@ -259,6 +295,14 @@ const doc = new Document({
                 new Paragraph({
                     text: "Test 2",
                     style: "normalPara2",
+                }),
+                new Paragraph({
+                    text: "Numbered paragraph that has numbering attached to custom styles",
+                    style: "numberedPara",
+                }),
+                new Paragraph({
+                    text: "Numbered para would show up in the styles pane at Word",
+                    style: "numberedPara",
                 }),
             ],
         },

--- a/src/export/packer/next-compiler.ts
+++ b/src/export/packer/next-compiler.ts
@@ -123,19 +123,23 @@ export class Compiler {
                 path: "word/document.xml",
             },
             Styles: {
-                data: xml(
-                    this.formatter.format(file.Styles, {
-                        viewWrapper: file.Document,
-                        file,
-                    }),
-                    {
-                        indent: prettify,
-                        declaration: {
-                            standalone: "yes",
-                            encoding: "UTF-8",
+                data: (() => {
+                    const xmlStyles = xml(
+                        this.formatter.format(file.Styles, {
+                            viewWrapper: file.Document,
+                            file,
+                        }),
+                        {
+                            indent: prettify,
+                            declaration: {
+                                standalone: "yes",
+                                encoding: "UTF-8",
+                            },
                         },
-                    },
-                ),
+                    );
+                    const referencedXmlStyles = this.numberingReplacer.replace(xmlStyles, file.Numbering.ConcreteNumbering);
+                    return referencedXmlStyles;
+                })(),
                 path: "word/styles.xml",
             },
             Properties: {

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -24,6 +24,12 @@ export interface IParagraphStylePropertiesOptions {
     readonly keepNext?: boolean;
     readonly keepLines?: boolean;
     readonly outlineLevel?: number;
+    readonly numbering?: {
+        readonly reference: string;
+        readonly level: number;
+        readonly instance?: number;
+        readonly custom?: boolean;
+    };
 }
 
 export interface IParagraphPropertiesOptions extends IParagraphStylePropertiesOptions {
@@ -39,12 +45,6 @@ export interface IParagraphPropertiesOptions extends IParagraphStylePropertiesOp
     readonly style?: string;
     readonly bullet?: {
         readonly level: number;
-    };
-    readonly numbering?: {
-        readonly reference: string;
-        readonly level: number;
-        readonly instance?: number;
-        readonly custom?: boolean;
     };
     readonly shading?: IShadingAttributesProperties;
     readonly widowControl?: boolean;


### PR DESCRIPTION
Issue: https://github.com/dolanmiu/docx/issues/1147
Here are my first deep touches on docx :) Interesting structure, I should admit, took some time to learn it.

To sum PR up:
1) Moved numbering props level higher at `src/file/paragraph/properties.ts`
from `IParagraphPropertiesOptions` to `IParagraphStylePropertiesOptions`
2) Added numId replacer at `src/export/packer/next-compiler.ts` for styles.xml
3) Added demo on how it meant to be used at `demo/11-declaritive-styles-2.ts`

Didn't came up with some good tests since numbering is covered, while NumberingReplacer isn't in general.