### PR TITLE
Separate paragraph style options interface for level

### DIFF
--- a/src/file/numbering/level.ts
+++ b/src/file/numbering/level.ts
@@ -2,7 +2,7 @@
 import { decimalNumber } from "file/values";
 import { Attributes, NumberValueElement, XmlAttributeComponent, XmlComponent } from "file/xml-components";
 import { AlignmentType } from "../paragraph/formatting";
-import { IParagraphStylePropertiesOptions, ParagraphProperties } from "../paragraph/properties";
+import { ILevelParagraphStylePropertiesOptions, ParagraphProperties } from "../paragraph/properties";
 import { IRunStylePropertiesOptions, RunProperties } from "../paragraph/run/properties";
 
 export enum LevelFormat {
@@ -88,7 +88,7 @@ export interface ILevelsOptions {
     readonly suffix?: LevelSuffix;
     readonly style?: {
         readonly run?: IRunStylePropertiesOptions;
-        readonly paragraph?: IParagraphStylePropertiesOptions;
+        readonly paragraph?: ILevelParagraphStylePropertiesOptions;
     };
 }
 

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -13,7 +13,7 @@ import { NumberProperties } from "./formatting/unordered-list";
 import { FrameProperties, IFrameOptions } from "./frame/frame-properties";
 import { OutlineLevel } from "./links";
 
-export interface IParagraphStylePropertiesOptions {
+export interface ILevelParagraphStylePropertiesOptions {
     readonly alignment?: AlignmentType;
     readonly thematicBreak?: boolean;
     readonly contextualSpacing?: boolean;
@@ -24,6 +24,9 @@ export interface IParagraphStylePropertiesOptions {
     readonly keepNext?: boolean;
     readonly keepLines?: boolean;
     readonly outlineLevel?: number;
+}
+
+export interface IParagraphStylePropertiesOptions extends ILevelParagraphStylePropertiesOptions {
     readonly numbering?: {
         readonly reference: string;
         readonly level: number;


### PR DESCRIPTION
Some polishing for this PR: https://github.com/dolanmiu/docx/pull/1163

The only place I found where IParagraphStylePropertiesOptions cannot have numbering property is level:
![image](https://user-images.githubusercontent.com/69673750/134059122-4ed7c07e-0234-479a-8e9a-4fa584090a1d.png)

This PR would keep automatically created API documentation cleaner (https://docx.js.org/api/modules.html)
BUT This PR doesn't limit user to put numbering which would lead to unopenable file like so:
![image](https://user-images.githubusercontent.com/69673750/134059462-93abb751-ea08-41d9-ba3e-5a2a97a5579e.png)
