### PR TITLE
Add suppressLineNumber option to Paragraph

### DIFF
--- a/demo/70-line-numbers-suppression.ts
+++ b/demo/70-line-numbers-suppression.ts
@@ -1,4 +1,4 @@
-// Example demonstrating line numbers.
+// Example demonstrating line numbers with suppression.
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
 import { Document, HeadingLevel, LineNumberRestartFormat, Packer, Paragraph } from "../build";

--- a/demo/70-line-numbers-suppression.ts
+++ b/demo/70-line-numbers-suppression.ts
@@ -1,0 +1,37 @@
+// Example demonstrating line numbers.
+// Import from 'docx' rather than '../build' if you install from npm
+import * as fs from "fs";
+import { Document, HeadingLevel, LineNumberRestartFormat, Packer, Paragraph } from "../build";
+
+const doc = new Document({
+    sections: [
+        {
+            properties: {
+                lineNumbers: {
+                    countBy: 1,
+                    restart: LineNumberRestartFormat.CONTINUOUS,
+                },
+            },
+            children: [
+                new Paragraph({
+                    text: "Hello",
+                    heading: HeadingLevel.HEADING_1,
+                }),
+                new Paragraph(
+                    "Himenaeos duis luctus nullam fermentum lobortis potenti vivamus non dis, sed facilisis ultricies scelerisque aenean risus hac senectus. Adipiscing id venenatis justo ante gravida placerat, ac curabitur dis pellentesque proin bibendum risus, aliquam porta taciti vulputate primis. Tortor ipsum fermentum quam vel convallis primis nisl praesent tincidunt, lobortis quisque felis vitae condimentum class ut sem nam, aenean potenti pretium ac amet lacinia himenaeos mi. Aliquam nisl turpis hendrerit est morbi malesuada, augue interdum mus inceptos curabitur tristique, parturient feugiat sodales nulla facilisi. Aliquam non pulvinar purus nulla ex integer, velit faucibus vitae at bibendum quam, risus elit aenean adipiscing posuere.",
+                ),
+                new Paragraph({
+                    text: 'Enim mollit nostrud ut dolor eiusmod id sit occaecat dolore culpa amet. Veniam dolor consequat dolor labore ullamco laborum dolore eiusmod qui adipisicing. Elit nulla cupidatat et magna. Id eiusmod tempor non laborum ipsum. Veniam et aliqua excepteur duis officia enim elit excepteur fugiat duis. Sit sunt ullamco non dolor est qui deserunt consequat magna. Esse pariatur esse dolor ut excepteur dolor nisi nisi non est cupidatat mollit.',
+                    suppressLineNumbers: true
+                }),
+                new Paragraph(
+                    "Sed laoreet id mattis egestas nam mollis elit lacinia convallis dui tincidunt ultricies habitant, pharetra per maximus interdum neque tempor risus efficitur morbi imperdiet senectus. Lectus laoreet senectus finibus inceptos donec potenti fermentum, ultrices eleifend odio suscipit magnis tellus maximus nibh, ac sit nullam eget felis himenaeos. Diam class sem magnis aenean commodo faucibus id proin mi, nullam sodales nec mus parturient ornare ad inceptos velit hendrerit, bibendum placerat eleifend integer facilisis urna dictumst suspendisse.",
+                ),
+            ],
+        },
+    ],
+});
+
+Packer.toBuffer(doc).then((buffer) => {
+    fs.writeFileSync("My Document.docx", buffer);
+});

--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -830,6 +830,18 @@ describe("Paragraph", () => {
         });
     });
 
+    describe("#suppressLineNumbers", () => {
+        it("should disable line numbers", () => {
+            const paragraph = new Paragraph({
+                suppressLineNumbers: true,
+            });
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.deep.equal({
+                "w:p": [{ "w:pPr": [{ "w:suppressLineNumbers": EMPTY_OBJECT }] }],
+            });
+        });
+    });
+
     describe("#outlineLevel", () => {
         it("should set paragraph outline level to the given value", () => {
             const paragraph = new Paragraph({

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -52,6 +52,7 @@ export interface IParagraphPropertiesOptions extends IParagraphStylePropertiesOp
     readonly shading?: IShadingAttributesProperties;
     readonly widowControl?: boolean;
     readonly frame?: IFrameOptions;
+    readonly suppressLineNumbers?: boolean;
 }
 
 export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
@@ -165,6 +166,10 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
 
         if (options.outlineLevel !== undefined) {
             this.push(new OutlineLevel(options.outlineLevel));
+        }
+
+        if (options.suppressLineNumbers !== undefined) {
+            this.push(new OnOffElement("w:suppressLineNumbers", options.suppressLineNumbers));
         }
     }
 

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -1,4 +1,5 @@
 // http://officeopenxml.com/WPparagraphProperties.php
+// https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_suppressLineNumbers_topic_ID0ECJAO.html
 import { IContext, IgnoreIfEmptyXmlComponent, IXmlableObject, OnOffElement, XmlComponent } from "file/xml-components";
 import { DocumentWrapper } from "../document-wrapper";
 import { IShadingAttributesProperties, Shading } from "../shading";


### PR DESCRIPTION
Adds an option to exclude a paragraph from line number counting. New Paragraph option follows the spec [here](https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_suppressLineNumbers_topic_ID0ECJAO.html)