### PR TITLE
Change type of revision to a number

### DIFF
--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -12,7 +12,7 @@ describe("Packer", () => {
     beforeEach(() => {
         file = new File({
             creator: "Dolan Miu",
-            revision: "1",
+            revision: 1,
             lastModifiedBy: "Dolan Miu",
             sections: [
                 {

--- a/src/file/core-properties/properties.spec.ts
+++ b/src/file/core-properties/properties.spec.ts
@@ -38,7 +38,7 @@ describe("Properties", () => {
                 keywords: "test docx",
                 description: "testing document",
                 lastModifiedBy: "the author",
-                revision: "123",
+                revision: 123,
             });
             const tree = new Formatter().format(properties);
             expect(Object.keys(tree)).to.deep.equal(["cp:coreProperties"]);

--- a/src/file/core-properties/properties.ts
+++ b/src/file/core-properties/properties.ts
@@ -17,7 +17,7 @@ export interface IPropertiesOptions {
     readonly keywords?: string;
     readonly description?: string;
     readonly lastModifiedBy?: string;
-    readonly revision?: string;
+    readonly revision?: number;
     readonly externalStyles?: string;
     readonly styles?: IStylesOptions;
     readonly numbering?: INumberingOptions;
@@ -89,7 +89,7 @@ export class CoreProperties extends XmlComponent {
             this.root.push(new StringContainer("cp:lastModifiedBy", options.lastModifiedBy));
         }
         if (options.revision) {
-            this.root.push(new StringContainer("cp:revision", options.revision));
+            this.root.push(new StringContainer("cp:revision", String(options.revision)));
         }
         this.root.push(new TimestampElement("dcterms:created"));
         this.root.push(new TimestampElement("dcterms:modified"));

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -57,7 +57,7 @@ export class File {
         this.coreProperties = new CoreProperties({
             ...options,
             creator: options.creator ?? "Un-named",
-            revision: options.revision ?? "1",
+            revision: options.revision ?? 1,
             lastModifiedBy: options.lastModifiedBy ?? "Un-named",
         });
 


### PR DESCRIPTION
I just worked through a bug that I didn't realize that `revision` in document properties had to be a number. I have changed the TypeScript to only allow numbers, which I think is clearer. This made the word doc angry when it was opened if there is arbitrary string in there.

![image](https://user-images.githubusercontent.com/913249/136629313-ded49818-be9b-4484-9cbf-527775cb3639.png)

The code change is backwards compatible as we cast this to a string before writing to XML. However, this will require people to unquote their revision numbers if they are using typescript.