### PR TITLE
fix #1261 use numeric ids with bookmarks

### DIFF
--- a/src/file/paragraph/links/bookmark-attributes.ts
+++ b/src/file/paragraph/links/bookmark-attributes.ts
@@ -1,7 +1,7 @@
 import { XmlAttributeComponent } from "file/xml-components";
 
 export class BookmarkStartAttributes extends XmlAttributeComponent<{
-    readonly id: string;
+    readonly id: number;
     readonly name: string;
 }> {
     protected readonly xmlKeys = {
@@ -11,7 +11,7 @@ export class BookmarkStartAttributes extends XmlAttributeComponent<{
 }
 
 export class BookmarkEndAttributes extends XmlAttributeComponent<{
-    readonly id: string;
+    readonly id: number;
 }> {
     protected readonly xmlKeys = {
         id: "w:id",

--- a/src/file/paragraph/links/bookmark.spec.ts
+++ b/src/file/paragraph/links/bookmark.spec.ts
@@ -36,6 +36,6 @@ describe("Bookmark", () => {
 
     it("should create a bookmark with the correct attributes on the bookmark end element", () => {
         const newJson = Utility.jsonify(bookmark);
-        expect(newJson.end.root[0].root.id).to.be.a("string");
+        expect(newJson.end.root[0].root.id).to.be.a("number");
     });
 });

--- a/src/file/paragraph/links/bookmark.ts
+++ b/src/file/paragraph/links/bookmark.ts
@@ -1,5 +1,5 @@
 // http://officeopenxml.com/WPbookmark.php
-import { uniqueId } from "convenience-functions";
+import { uniqueNumericId } from "convenience-functions";
 import { XmlComponent } from "file/xml-components";
 
 import { ParagraphChild } from "../paragraph";
@@ -11,7 +11,7 @@ export class Bookmark {
     public readonly end: BookmarkEnd;
 
     constructor(options: { readonly id: string; readonly children: ParagraphChild[] }) {
-        const linkId = uniqueId();
+        const linkId = uniqueNumericId();
 
         this.start = new BookmarkStart(options.id, linkId);
         this.children = options.children;
@@ -19,8 +19,40 @@ export class Bookmark {
     }
 }
 
+// <xsd:element name="bookmarkStart" type="CT_Bookmark"/>
+// <xsd:element name="bookmarkEnd" type="CT_MarkupRange"/>
+
+// <xsd:complexType name="CT_Bookmark">
+//   <xsd:complexContent>
+//     <xsd:extension base="CT_BookmarkRange">
+//     <xsd:attribute name="name" type="s:ST_String" use="required"/>
+//     </xsd:extension>
+//   </xsd:complexContent>
+// </xsd:complexType>
+
+// <xsd:complexType name="CT_BookmarkRange">
+//   <xsd:complexContent>
+//     <xsd:extension base="CT_MarkupRange">
+//       <xsd:attribute name="colFirst" type="ST_DecimalNumber" use="optional"/>
+//       <xsd:attribute name="colLast" type="ST_DecimalNumber" use="optional"/>
+//     </xsd:extension>
+//   </xsd:complexContent>
+// </xsd:complexType>
+
+// <xsd:complexType name="CT_MarkupRange">
+//   <xsd:complexContent>
+//     <xsd:extension base="CT_Markup">
+//       <xsd:attribute name="displacedByCustomXml" type="ST_DisplacedByCustomXml" use="optional"/>
+//     </xsd:extension>
+//   </xsd:complexContent>
+// </xsd:complexType>
+
+// <xsd:complexType name="CT_Markup">
+//   <xsd:attribute name="id" type="ST_DecimalNumber" use="required"/>
+// </xsd:complexType>
+
 export class BookmarkStart extends XmlComponent {
-    constructor(id: string, linkId: string) {
+    constructor(id: string, linkId: number) {
         super("w:bookmarkStart");
 
         const attributes = new BookmarkStartAttributes({
@@ -32,7 +64,7 @@ export class BookmarkStart extends XmlComponent {
 }
 
 export class BookmarkEnd extends XmlComponent {
-    constructor(linkId: string) {
+    constructor(linkId: number) {
         super("w:bookmarkEnd");
 
         const attributes = new BookmarkEndAttributes({

--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -22,6 +22,9 @@ describe("Paragraph", () => {
         stub(convenienceFunctions, "uniqueId").callsFake(() => {
             return "test-unique-id";
         });
+        stub(convenienceFunctions, "uniqueNumericId").callsFake(() => {
+            return -101;
+        });
     });
 
     after(() => {
@@ -716,7 +719,7 @@ describe("Paragraph", () => {
                 {
                     "w:bookmarkStart": {
                         _attr: {
-                            "w:id": "test-unique-id",
+                            "w:id": -101,
                             "w:name": "test-id",
                         },
                     },
@@ -738,7 +741,7 @@ describe("Paragraph", () => {
                 {
                     "w:bookmarkEnd": {
                         _attr: {
-                            "w:id": "test-unique-id",
+                            "w:id": -101,
                         },
                     },
                 },


### PR DESCRIPTION
Fixes #1261. bookmarkStart and bookmarkEnd should use a ST_DecimalNumber for the `id` attribute according to the schema.