### PR TITLE
Dont set background color if none is provided in options

### DIFF
--- a/src/file/document/document-background/document-background.spec.ts
+++ b/src/file/document/document-background/document-background.spec.ts
@@ -6,14 +6,12 @@ import { DocumentBackground } from "./document-background";
 
 describe("DocumentBackground", () => {
     describe("#constructor()", () => {
-        it("should create a DocumentBackground with no options and set color to auto", () => {
+        it("should create a DocumentBackground with no options", () => {
             const documentBackground = new DocumentBackground({});
             const tree = new Formatter().format(documentBackground);
             expect(tree).to.deep.equal({
                 "w:background": {
-                    _attr: {
-                        "w:color": "FFFFFF",
-                    },
+                    _attr: {},
                 },
             });
         });

--- a/src/file/document/document-background/document-background.ts
+++ b/src/file/document/document-background/document-background.ts
@@ -26,7 +26,7 @@ import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
 // </xsd:simpleType>
 
 export class DocumentBackgroundAttributes extends XmlAttributeComponent<{
-    readonly color: string;
+    readonly color?: string;
     readonly themeColor?: string;
     readonly themeShade?: string;
     readonly themeTint?: string;
@@ -68,7 +68,7 @@ export class DocumentBackground extends XmlComponent {
 
         this.root.push(
             new DocumentBackgroundAttributes({
-                color: hexColorValue(options.color ? options.color : "FFFFFF"),
+                color: options.color === undefined ? undefined : hexColorValue(options.color),
                 themeColor: options.themeColor,
                 themeShade: options.themeShade === undefined ? undefined : uCharHexNumber(options.themeShade),
                 themeTint: options.themeTint === undefined ? undefined : uCharHexNumber(options.themeTint),

--- a/src/file/document/document.spec.ts
+++ b/src/file/document/document.spec.ts
@@ -40,9 +40,7 @@ describe("Document", () => {
                     },
                     {
                         "w:background": {
-                            _attr: {
-                                "w:color": "FFFFFF",
-                            },
+                            _attr: {},
                         },
                     },
                     { "w:body": {} },


### PR DESCRIPTION
After comparing the output of this library and what is
produced by Microsoft Word, it seems that document
background color is not set by default by Word.

Removing the default #FFFFFF background color enables the
generated documents to be readable in dark mode.

This seems to fix dolanmiu/docx#1093