### PR TITLE
Add an ability to specify charSpace and type for DocumentGrid

### DIFF
--- a/src/file/document/body/section-properties/properties/doc-grid.spec.ts
+++ b/src/file/document/body/section-properties/properties/doc-grid.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+
+import { Formatter } from "export/formatter";
+
+import { DocumentGrid, DocumentGridType } from ".";
+
+describe("DocumentGrid", () => {
+    describe("#constructor()", () => {
+        it("should create documentGrid with specified linePitch", () => {
+            const docGrid = new DocumentGrid(360);
+            const tree = new Formatter().format(docGrid);
+
+            expect(tree["w:docGrid"]).to.deep.equal({ _attr: { "w:linePitch": 360 } });
+        });
+
+        it("should create documentGrid with specified linePitch and type", () => {
+            const docGrid = new DocumentGrid(360, undefined, DocumentGridType.LINES);
+            const tree = new Formatter().format(docGrid);
+
+            expect(tree["w:docGrid"]).to.deep.equal({ _attr: { "w:linePitch": 360, "w:type": "lines" } });
+        });
+
+        it("should create documentGrid with specified linePitch,charSpace and type", () => {
+            const docGrid = new DocumentGrid(346, -1541, DocumentGridType.LINES_AND_CHARS);
+            const tree = new Formatter().format(docGrid);
+
+            expect(tree["w:docGrid"]).to.deep.equal({ _attr: { "w:linePitch": 346, "w:charSpace": -1541, "w:type": "linesAndChars" } });
+        });
+    });
+});

--- a/src/file/document/body/section-properties/properties/doc-grid.ts
+++ b/src/file/document/body/section-properties/properties/doc-grid.ts
@@ -16,22 +16,36 @@ import { XmlAttributeComponent, XmlComponent } from "file/xml-components";
 //     <xsd:attribute name="linePitch" type="ST_DecimalNumber"/>
 //     <xsd:attribute name="charSpace" type="ST_DecimalNumber"/>
 // </xsd:complexType>
+
+export enum DocumentGridType {
+    DEFAULT = "default",
+    LINES = "lines",
+    LINES_AND_CHARS = "linesAndChars",
+    SNAP_TO_CHARS = "snapToChars",
+}
 export interface IDocGridAttributesProperties {
+    readonly type?: DocumentGridType;
     readonly linePitch?: number;
+    readonly charSpace?: number;
 }
 
 export class DocGridAttributes extends XmlAttributeComponent<IDocGridAttributesProperties> {
     protected readonly xmlKeys = {
+        type: "w:type",
         linePitch: "w:linePitch",
+        charSpace: "w:charSpace",
     };
 }
 
 export class DocumentGrid extends XmlComponent {
-    constructor(linePitch: number) {
+    constructor(linePitch: number, charSpace?: number, type?: DocumentGridType) {
         super("w:docGrid");
+
         this.root.push(
             new DocGridAttributes({
+                type: type,
                 linePitch: decimalNumber(linePitch),
+                charSpace: charSpace ? decimalNumber(charSpace) : undefined,
             }),
         );
     }

--- a/src/file/document/body/section-properties/section-properties.spec.ts
+++ b/src/file/document/body/section-properties/section-properties.spec.ts
@@ -9,6 +9,7 @@ import { NumberFormat } from "file/shared/number-format";
 import { VerticalAlign } from "file/vertical-align";
 
 import { PageOrientation } from "./properties";
+import { DocumentGridType } from "./properties/doc-grid";
 import { LineNumberRestartFormat } from "./properties/line-number";
 import { PageBorderOffsetFrom } from "./properties/page-borders";
 import { PageTextDirectionType } from "./properties/page-text-direction";
@@ -64,6 +65,7 @@ describe("SectionProperties", () => {
                 },
                 grid: {
                     linePitch: convertInchesToTwip(0.25),
+                    type: DocumentGridType.LINES,
                 },
                 headerWrapperGroup: {
                     default: new HeaderWrapper(media, 100),
@@ -100,7 +102,7 @@ describe("SectionProperties", () => {
             expect(tree["w:sectPr"][5]).to.deep.equal({ "w:cols": { _attr: { "w:space": 208, "w:sep": true, "w:num": 2 } } });
             expect(tree["w:sectPr"][6]).to.deep.equal({ "w:vAlign": { _attr: { "w:val": "top" } } });
             expect(tree["w:sectPr"][7]).to.deep.equal({ "w:titlePg": {} });
-            expect(tree["w:sectPr"][8]).to.deep.equal({ "w:docGrid": { _attr: { "w:linePitch": 360 } } });
+            expect(tree["w:sectPr"][8]).to.deep.equal({ "w:docGrid": { _attr: { "w:linePitch": 360, "w:type": "lines" } } });
         });
 
         it("should create section properties with no options", () => {

--- a/src/file/document/body/section-properties/section-properties.ts
+++ b/src/file/document/body/section-properties/section-properties.ts
@@ -112,7 +112,7 @@ export class SectionProperties extends XmlComponent {
             borders,
             textDirection,
         } = {},
-        grid: { linePitch = 360 } = {},
+        grid: { linePitch = 360, charSpace, type: gridType } = {},
         headerWrapperGroup = {},
         footerWrapperGroup = {},
         lineNumbers,
@@ -159,7 +159,7 @@ export class SectionProperties extends XmlComponent {
             this.root.push(new PageTextDirection(textDirection));
         }
 
-        this.root.push(new DocumentGrid(linePitch));
+        this.root.push(new DocumentGrid(linePitch, charSpace, gridType));
     }
 
     private addHeaderFooterGroup(


### PR DESCRIPTION
This PR adds  an ability to specify `charSpace` and `type` properties of `DocumentGrid`
<img width="522" alt="DocumentGrid" src="https://user-images.githubusercontent.com/32659/144046679-d306a937-97ff-4277-8019-bc3bd19b3c73.png">
.
