### PR TITLE
Fix reading template images in the browser

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# https://prettier.io/docs/en/options.html#end-of-line
+* text=auto eol=lf

--- a/src/import-dotx/import-dotx.ts
+++ b/src/import-dotx/import-dotx.ts
@@ -157,7 +157,8 @@ export class ImportDotx {
         const hyperLinkReferences = this.findReferenceFiles(xmlRef).filter((r) => r.type === RelationshipType.HYPERLINK);
 
         for (const r of wrapperImagesReferences) {
-            const buffer = await zipContent.files[`word/${r.target}`].async("nodebuffer");
+            const bufferType = JSZip.support.arraybuffer ? "arraybuffer" : "nodebuffer";
+            const buffer = await zipContent.files[`word/${r.target}`].async(bufferType);
             const mediaData = media.addMedia(buffer, {
                 width: 100,
                 height: 100,


### PR DESCRIPTION
[Media.addMedia()](https://github.com/dolanmiu/docx/blob/master/src/file/media/media.ts#L23) supports both node `Buffer` and `ArrayBuffer`, so check if we are running in the browser and use `ArrayBuffer`, instead of node `Buffer`, so we don't need to rely on a node buffer polyfill as [described in my comment](https://github.com/dolanmiu/docx/issues/1272#issuecomment-1017618628).

Fix #1272