### PR TITLE
Recommend to install `Code Spell Checker` Extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker"
+    ]
+}


### PR DESCRIPTION
Since I saw some [cSpell definitions in the settings](https://github.com/dolanmiu/docx/blob/master/.vscode/settings.json#L2=), why not also recommend to install the extension?