### PR TITLE
Add toString to Packer

### DIFF
--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -37,6 +37,14 @@ describe("Packer", () => {
         });
     });
 
+    describe("#toString()", () => {
+        it("should return a non-empty string", async () => {
+            const result = await Packer.toString(file);
+
+            assert.isAbove(result.length, 0);
+        });
+    });
+
     describe("#toBuffer()", () => {
         it("should create a standard docx file", async function () {
             this.timeout(99999999);

--- a/src/export/packer/packer.ts
+++ b/src/export/packer/packer.ts
@@ -13,6 +13,17 @@ export enum PrettifyType {
 }
 
 export class Packer {
+    public static async toString(file: File, prettify?: boolean | PrettifyType): Promise<string> {
+        const zip = this.compiler.compile(file, prettify);
+        const zipData = await zip.generateAsync({
+            type: "string",
+            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            compression: "DEFLATE",
+        });
+
+        return zipData;
+    }
+
     public static async toBuffer(file: File, prettify?: boolean | PrettifyType): Promise<Buffer> {
         const zip = this.compiler.compile(file, prettify);
         const zipData = await zip.generateAsync({


### PR DESCRIPTION
I found that having `toBase64String` but not `toString` is kinda weird, so I wrote it myself, which ended up the same as the other methods except for changing the `type` property.

Do I need to write a test for this to be approved? It's almost the same as the other methods and it works on my app. One thing I was concerned about was breaking the built-in JS `toString` function, however I don't think this class is converted to a string anywhere, is it?