### PR TITLE
Create packer stream "toStream"

### DIFF
--- a/demo/74-nodejs-stream.ts
+++ b/demo/74-nodejs-stream.ts
@@ -1,0 +1,31 @@
+// Simple example to add text to a document
+// Import from 'docx' rather than '../build' if you install from npm
+import * as fs from "fs";
+import { Document, Packer, Paragraph, TextRun } from "../build";
+
+const doc = new Document({
+    sections: [
+        {
+            properties: {},
+            children: [
+                new Paragraph({
+                    children: [
+                        new TextRun("Hello World"),
+                        new TextRun({
+                            text: "Foo Bar",
+                            bold: true,
+                        }),
+                        new TextRun({
+                            text: "\tGithub is the best",
+                            bold: true,
+                        }),
+                    ],
+                }),
+            ],
+        },
+    ],
+});
+
+Packer.toStream(doc).then((stream) => {
+    stream.pipe(fs.createWriteStream("My Document.docx"));
+});

--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -152,7 +152,7 @@ describe("Packer", () => {
             }));
 
             compiler.throwsException();
-            return await Packer.toStream(file).catch((error) => {
+            return Packer.toStream(file).catch((error) => {
                 assert.isDefined(error);
             });
         });

--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -114,4 +114,52 @@ describe("Packer", () => {
             (Packer as any).compiler.compile.restore();
         });
     });
+
+    describe("#toStream()", () => {
+        it("should create a standard docx file", async () => {
+            // tslint:disable-next-line: no-any
+            stub((Packer as any).compiler, "compile").callsFake(() => ({
+                // tslint:disable-next-line: no-empty
+                generateNodeStream: () => ({
+                    on: (event: string, cb: () => void) => {
+                        if (event === "end") {
+                            cb();
+                        }
+                    },
+                }),
+            }));
+            const stream = await Packer.toStream(file);
+            return new Promise((resolve, reject) => {
+                stream.on("error", () => {
+                    reject();
+                });
+
+                stream.on("end", () => {
+                    resolve();
+                });
+            });
+        });
+
+        it("should handle exception if it throws any", async () => {
+            // tslint:disable-next-line:no-any
+            const compiler = stub((Packer as any).compiler, "compile").callsFake(() => ({
+                // tslint:disable-next-line: no-empty
+                on: (event: string, cb: () => void) => {
+                    if (event === "error") {
+                        cb();
+                    }
+                },
+            }));
+
+            compiler.throwsException();
+            return await Packer.toStream(file).catch((error) => {
+                assert.isDefined(error);
+            });
+        });
+
+        afterEach(() => {
+            // tslint:disable-next-line:no-any
+            (Packer as any).compiler.compile.restore();
+        });
+    });
 });

--- a/src/export/packer/packer.ts
+++ b/src/export/packer/packer.ts
@@ -1,4 +1,5 @@
 import { File } from "@file/file";
+import { Stream } from "stream";
 
 import { Compiler } from "./next-compiler";
 
@@ -39,6 +40,18 @@ export class Packer {
         const zip = this.compiler.compile(file, prettify);
         const zipData = await zip.generateAsync({
             type: "blob",
+            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            compression: "DEFLATE",
+        });
+
+        return zipData;
+    }
+    
+    public static async toStream(file: File, prettify?: boolean | PrettifyType): Promise<Stream> {
+        const zip = this.compiler.compile(file, prettify);
+        const zipData = zip.generateNodeStream({
+            type: "nodebuffer",
+            streamFiles: true,
             mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             compression: "DEFLATE",
         });

--- a/src/export/packer/packer.ts
+++ b/src/export/packer/packer.ts
@@ -46,7 +46,7 @@ export class Packer {
 
         return zipData;
     }
-    
+
     public static async toStream(file: File, prettify?: boolean | PrettifyType): Promise<Stream> {
         const zip = this.compiler.compile(file, prettify);
         const zipData = zip.generateNodeStream({

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -23,6 +23,9 @@ const configuration = {
             stream: require.resolve("stream-browserify"),
         },
         plugins: [new TsconfigPathsPlugin()],
+        alias: {
+            jszip: require.resolve('jszip/lib/index.js'),
+        },
     },
 
     module: {


### PR DESCRIPTION
This creates a new DOCX export function that returns a readable stream.  I created this to help reduce memory needs when generating a document with a log of image files.

I had to update the webpack config file because JSZip was not detecting the NodeJS stream object during testing and threw errors for jszip.generateNodeStream() function.