### PR TITLE
Added the name horizontal line or horizontal rules

### DIFF
--- a/docs/usage/paragraph.md
+++ b/docs/usage/paragraph.md
@@ -111,7 +111,7 @@ const paragraph = new Paragraph({
 
 ## Border
 
-Add borders to a `Paragraph`. Good for making the `Paragraph` stand out
+Add borders to a `Paragraph`. Good for making the `Paragraph` stand out. Also called horizontal lines or horizontal rules.
 
 #### IBorderPropertyOptions
 


### PR DESCRIPTION
There was some confusion in https://github.com/dolanmiu/docx/issues/437 because the docs don't mention anything called horizontal lines or horizontal rules. 

Microsoft calls them by those names here https://support.microsoft.com/en-us/office/insert-a-line-9bf172f6-5908-4791-9bb9-2c952197b1a9 

This will make it easier for people to find this feature in the docs.