### PR TITLE
FIX: multiple tabStop support for LibreWriter

### DIFF
--- a/demo/75-tab-stops.ts
+++ b/demo/75-tab-stops.ts
@@ -4,19 +4,18 @@ import * as fs from "fs";
 import { Document, HeadingLevel, Packer, Paragraph, TabStopPosition, TabStopType, TextRun } from "../build";
 
 const columnWidth = TabStopPosition.MAX / 4;
-const reciptTabStops = [
-    // no need to define first left tab column
-    // the right aligned tab column position should point to the end of column
-    // i.e. in this case 
-    // (end position of 1st) + (end position of current)
-    // columnWidth + columnWidth = columnWidth * 2
-    
-    {  type: TabStopType.RIGHT, position: columnWidth * 2 },
-    {  type: TabStopType.RIGHT, position: columnWidth * 3 },
-    {  type: TabStopType.RIGHT, position: TabStopPosition.MAX } 
-], twoTabStops = [
-    {  type: TabStopType.RIGHT, position: TabStopPosition.MAX }
-];
+const receiptTabStops = [
+        // no need to define first left tab column
+        // the right aligned tab column position should point to the end of column
+        // i.e. in this case
+        // (end position of 1st) + (end position of current)
+        // columnWidth + columnWidth = columnWidth * 2
+
+        { type: TabStopType.RIGHT, position: columnWidth * 2 },
+        { type: TabStopType.RIGHT, position: columnWidth * 3 },
+        { type: TabStopType.RIGHT, position: TabStopPosition.MAX },
+    ],
+    twoTabStops = [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }];
 
 const doc = new Document({
     sections: [
@@ -25,62 +24,57 @@ const doc = new Document({
             children: [
                 new Paragraph({
                     heading: HeadingLevel.HEADING_1,
-                    children: [ new TextRun("Recipt 001")],
+                    children: [new TextRun("Receipt 001")],
                 }),
                 new Paragraph({
                     tabStops: twoTabStops,
-                    children: [ 
-                        new TextRun({ 
+                    children: [
+                        new TextRun({
                             text: "To Bob.\tBy Alice.",
-                            bold: true
-                        })
+                            bold: true,
+                        }),
                     ],
-                    
                 }),
                 new Paragraph({
                     tabStops: twoTabStops,
-                    children: [ 
-                        new TextRun("Foo Inc\tBar Inc")
-                    ],
+                    children: [new TextRun("Foo Inc\tBar Inc")],
                 }),
-                new Paragraph({text: ""}),
+                new Paragraph({ text: "" }),
                 new Paragraph({
-                    tabStops: reciptTabStops,
-                    
+                    tabStops: receiptTabStops,
+
                     children: [
                         new TextRun({
                             text: "Item\tPrice\tQuantity\tSub-total",
-                            bold: true
-                        })
+                            bold: true,
+                        }),
                     ],
                 }),
                 new Paragraph({
-                    tabStops: reciptTabStops,
+                    tabStops: receiptTabStops,
                     text: "Item 3\t10\t5\t50",
                 }),
                 new Paragraph({
-                    tabStops: reciptTabStops,
+                    tabStops: receiptTabStops,
                     text: "Item 3\t10\t5\t50",
                 }),
                 new Paragraph({
-                    tabStops: reciptTabStops,
-                    text: "Item 3\t10\t5\t50"
+                    tabStops: receiptTabStops,
+                    text: "Item 3\t10\t5\t50",
                 }),
                 new Paragraph({
-                    tabStops: reciptTabStops,
+                    tabStops: receiptTabStops,
                     children: [
                         new TextRun({
                             text: "\t\t\tTotal: 200",
-                            bold: true
-                        })
+                            bold: true,
+                        }),
                     ],
-                })
+                }),
             ],
         },
     ],
 });
 
-
 const stream = Packer.toStream(doc);
 stream.pipe(fs.createWriteStream("My Document.docx"));
-

--- a/demo/75-tab-stops.ts
+++ b/demo/75-tab-stops.ts
@@ -70,7 +70,7 @@ const doc = new Document({
                     tabStops: reciptTabStops,
                     children: [
                         new TextRun({
-                            text: "\t\tTotal: 200",
+                            text: "\t\t\tTotal: 200",
                             bold: true
                         })
                     ],

--- a/demo/75-tab-stops.ts
+++ b/demo/75-tab-stops.ts
@@ -1,0 +1,86 @@
+// Exporting the document as a stream
+// Import from 'docx' rather than '../build' if you install from npm
+import * as fs from "fs";
+import { Document, HeadingLevel, Packer, Paragraph, TabStopPosition, TabStopType, TextRun } from "../build";
+
+const columnWidth = TabStopPosition.MAX / 4;
+const reciptTabStops = [
+    // no need to define first left tab column
+    // the right aligned tab column position should point to the end of column
+    // i.e. in this case 
+    // (end position of 1st) + (end position of current)
+    // columnWidth + columnWidth = columnWidth * 2
+    
+    {  type: TabStopType.RIGHT, position: columnWidth * 2 },
+    {  type: TabStopType.RIGHT, position: columnWidth * 3 },
+    {  type: TabStopType.RIGHT, position: TabStopPosition.MAX } 
+], twoTabStops = [
+    {  type: TabStopType.RIGHT, position: TabStopPosition.MAX }
+];
+
+const doc = new Document({
+    sections: [
+        {
+            properties: {},
+            children: [
+                new Paragraph({
+                    heading: HeadingLevel.HEADING_1,
+                    children: [ new TextRun("Recipt 001")],
+                }),
+                new Paragraph({
+                    tabStops: twoTabStops,
+                    children: [ 
+                        new TextRun({ 
+                            text: "To Bob.\tBy Alice.",
+                            bold: true
+                        })
+                    ],
+                    
+                }),
+                new Paragraph({
+                    tabStops: twoTabStops,
+                    children: [ 
+                        new TextRun("Foo Inc\tBar Inc")
+                    ],
+                }),
+                new Paragraph({text: ""}),
+                new Paragraph({
+                    tabStops: reciptTabStops,
+                    
+                    children: [
+                        new TextRun({
+                            text: "Item\tPrice\tQuantity\tSub-total",
+                            bold: true
+                        })
+                    ],
+                }),
+                new Paragraph({
+                    tabStops: reciptTabStops,
+                    text: "Item 3\t10\t5\t50",
+                }),
+                new Paragraph({
+                    tabStops: reciptTabStops,
+                    text: "Item 3\t10\t5\t50",
+                }),
+                new Paragraph({
+                    tabStops: reciptTabStops,
+                    text: "Item 3\t10\t5\t50"
+                }),
+                new Paragraph({
+                    tabStops: reciptTabStops,
+                    children: [
+                        new TextRun({
+                            text: "\t\tTotal: 200",
+                            bold: true
+                        })
+                    ],
+                })
+            ],
+        },
+    ],
+});
+
+
+const stream = Packer.toStream(doc);
+stream.pipe(fs.createWriteStream("My Document.docx"));
+

--- a/src/file/paragraph/formatting/tab-stop.spec.ts
+++ b/src/file/paragraph/formatting/tab-stop.spec.ts
@@ -8,7 +8,7 @@ describe("LeftTabStop", () => {
     let tabStop: TabStop;
 
     beforeEach(() => {
-        tabStop = new TabStop({ type: TabStopType.LEFT, position: 100});
+        tabStop = new TabStop({ type: TabStopType.LEFT, position: 100 });
     });
 
     describe("#constructor()", () => {
@@ -32,7 +32,7 @@ describe("RightTabStop", () => {
     let tabStop: TabStop;
 
     beforeEach(() => {
-        tabStop = new TabStop({ type: TabStopType.RIGHT, position: 100, leader: LeaderType.DOT});
+        tabStop = new TabStop({ type: TabStopType.RIGHT, position: 100, leader: LeaderType.DOT });
     });
 
     describe("#constructor()", () => {

--- a/src/file/paragraph/formatting/tab-stop.spec.ts
+++ b/src/file/paragraph/formatting/tab-stop.spec.ts
@@ -8,7 +8,7 @@ describe("LeftTabStop", () => {
     let tabStop: TabStop;
 
     beforeEach(() => {
-        tabStop = new TabStop({ type: TabStopType.LEFT, position: 100 });
+        tabStop = new TabStop([{ type: TabStopType.LEFT, position: 100 }]);
     });
 
     describe("#constructor()", () => {
@@ -32,7 +32,7 @@ describe("RightTabStop", () => {
     let tabStop: TabStop;
 
     beforeEach(() => {
-        tabStop = new TabStop({ type: TabStopType.RIGHT, position: 100, leader: LeaderType.DOT });
+        tabStop = new TabStop([{ type: TabStopType.RIGHT, position: 100, leader: LeaderType.DOT }]);
     });
 
     describe("#constructor()", () => {

--- a/src/file/paragraph/formatting/tab-stop.spec.ts
+++ b/src/file/paragraph/formatting/tab-stop.spec.ts
@@ -8,7 +8,7 @@ describe("LeftTabStop", () => {
     let tabStop: TabStop;
 
     beforeEach(() => {
-        tabStop = new TabStop(TabStopType.LEFT, 100);
+        tabStop = new TabStop({ type: TabStopType.LEFT, position: 100});
     });
 
     describe("#constructor()", () => {
@@ -32,7 +32,7 @@ describe("RightTabStop", () => {
     let tabStop: TabStop;
 
     beforeEach(() => {
-        tabStop = new TabStop(TabStopType.RIGHT, 100, LeaderType.DOT);
+        tabStop = new TabStop({ type: TabStopType.RIGHT, position: 100, leader: LeaderType.DOT});
     });
 
     describe("#constructor()", () => {

--- a/src/file/paragraph/formatting/tab-stop.ts
+++ b/src/file/paragraph/formatting/tab-stop.ts
@@ -2,21 +2,23 @@
 import { XmlAttributeComponent, XmlComponent } from "@file/xml-components";
 
 export interface TabStopDefinition {
-    type: TabStopType, 
-    position: number | TabStopPosition, 
-    leader?: LeaderType
-}    
+    type: TabStopType;
+    position: number | TabStopPosition;
+    leader?: LeaderType;
+}
 
 export class TabStop extends XmlComponent {
-    public constructor(tabDefs: (TabStopDefinition[] | TabStopDefinition | TabStopType), position?: number, leader?: LeaderType)  {
+    public constructor(tabDefs: TabStopDefinition[] | TabStopDefinition | TabStopType, position?: number, leader?: LeaderType) {
         super("w:tabs");
-        if (typeof tabDefs === "string"){
+        if (typeof tabDefs === "string") {
             this.root.push(new TabStopItem(tabDefs, position, leader));
         } else {
             if (Array.isArray(tabDefs)) {
-                tabDefs.forEach((function(tabDef) {
-                    this.root.push(new TabStopItem(tabDef));
-                }).bind(this));
+                tabDefs.forEach(
+                    function (tabDef) {
+                        this.root.push(new TabStopItem(tabDef));
+                    }.bind(this),
+                );
             } else {
                 this.root.push(new TabStopItem(tabDefs));
             }
@@ -57,7 +59,7 @@ export class TabAttributes extends XmlAttributeComponent<{
 }
 
 export class TabStopItem extends XmlComponent {
-    public constructor(tabDef: (TabStopDefinition |  TabStopType), position?: number, leader?: LeaderType) {
+    public constructor(tabDef: TabStopDefinition | TabStopType, position?: number, leader?: LeaderType) {
         super("w:tab");
         if (typeof tabDef === "string") {
             if (typeof position === "number")
@@ -75,7 +77,7 @@ export class TabStopItem extends XmlComponent {
                     val: tabDef.type,
                     pos: tabDef.position,
                     leader: tabDef.leader,
-                })
+                }),
             );
         }
     }

--- a/src/file/paragraph/formatting/tab-stop.ts
+++ b/src/file/paragraph/formatting/tab-stop.ts
@@ -8,14 +8,18 @@ export interface TabStopDefinition {
 }    
 
 export class TabStop extends XmlComponent {
-    public constructor(tabDefs: (TabStopDefinition[] | TabStopDefinition))  {
+    public constructor(tabDefs: (TabStopDefinition[] | TabStopDefinition | TabStopType), position?: number, leader?: LeaderType)  {
         super("w:tabs");
-        if (Array.isArray(tabDefs)) {
-            tabDefs.forEach((function(tabDef) {
-                this.root.push(new TabStopItem(tabDef));
-            }).bind(this));
+        if (typeof tabDefs === "string"){
+            this.root.push(new TabStopItem(tabDefs, position, leader));
         } else {
-            this.root.push(new TabStopItem(tabDefs));
+            if (Array.isArray(tabDefs)) {
+                tabDefs.forEach((function(tabDef) {
+                    this.root.push(new TabStopItem(tabDef));
+                }).bind(this));
+            } else {
+                this.root.push(new TabStopItem(tabDefs));
+            }
         }
     }
 }
@@ -53,14 +57,26 @@ export class TabAttributes extends XmlAttributeComponent<{
 }
 
 export class TabStopItem extends XmlComponent {
-    public constructor(tabDef: TabStopDefinition) {
+    public constructor(tabDef: (TabStopDefinition |  TabStopType), position?: number, leader?: LeaderType) {
         super("w:tab");
-        this.root.push(
-            new TabAttributes({
-                val: tabDef.type,
-                pos: tabDef.position,
-                leader: tabDef.leader,
-            })
-        );
+        if (typeof tabDef === "string") {
+            if (typeof position === "number")
+                this.root.push(
+                    new TabAttributes({
+                        val: tabDef,
+                        pos: position,
+                        leader,
+                    }),
+                );
+            else throw Error("Undefined position: " + position);
+        } else {
+            this.root.push(
+                new TabAttributes({
+                    val: tabDef.type,
+                    pos: tabDef.position,
+                    leader: tabDef.leader,
+                })
+            );
+        }
     }
 }

--- a/src/file/paragraph/formatting/tab-stop.ts
+++ b/src/file/paragraph/formatting/tab-stop.ts
@@ -1,10 +1,22 @@
 // http://officeopenxml.com/WPtab.php
 import { XmlAttributeComponent, XmlComponent } from "@file/xml-components";
 
+export interface TabStopDefinition {
+    type: TabStopType, 
+    position: number | TabStopPosition, 
+    leader?: LeaderType
+}    
+
 export class TabStop extends XmlComponent {
-    public constructor(type: TabStopType, position: number, leader?: LeaderType) {
+    public constructor(tabDefs: (TabStopDefinition[] | TabStopDefinition))  {
         super("w:tabs");
-        this.root.push(new TabStopItem(type, position, leader));
+        if (Array.isArray(tabDefs)) {
+            tabDefs.forEach((function(tabDef) {
+                this.root.push(new TabStopItem(tabDef));
+            }).bind(this));
+        } else {
+            this.root.push(new TabStopItem(tabDefs));
+        }
     }
 }
 
@@ -41,14 +53,14 @@ export class TabAttributes extends XmlAttributeComponent<{
 }
 
 export class TabStopItem extends XmlComponent {
-    public constructor(value: TabStopType, position: string | number, leader?: LeaderType) {
+    public constructor(tabDef: TabStopDefinition) {
         super("w:tab");
         this.root.push(
             new TabAttributes({
-                val: value,
-                pos: position,
-                leader,
-            }),
+                val: tabDef.type,
+                pos: tabDef.position,
+                leader: tabDef.leader,
+            })
         );
     }
 }

--- a/src/file/paragraph/formatting/tab-stop.ts
+++ b/src/file/paragraph/formatting/tab-stop.ts
@@ -2,26 +2,17 @@
 import { XmlAttributeComponent, XmlComponent } from "@file/xml-components";
 
 export interface TabStopDefinition {
-    type: TabStopType;
-    position: number | TabStopPosition;
-    leader?: LeaderType;
+    readonly type: TabStopType;
+    readonly position: number | TabStopPosition;
+    readonly leader?: LeaderType;
 }
 
 export class TabStop extends XmlComponent {
-    public constructor(tabDefs: TabStopDefinition[] | TabStopDefinition | TabStopType, position?: number, leader?: LeaderType) {
+    public constructor(tabDefinitions: readonly TabStopDefinition[]) {
         super("w:tabs");
-        if (typeof tabDefs === "string") {
-            this.root.push(new TabStopItem(tabDefs, position, leader));
-        } else {
-            if (Array.isArray(tabDefs)) {
-                tabDefs.forEach(
-                    function (tabDef) {
-                        this.root.push(new TabStopItem(tabDef));
-                    }.bind(this),
-                );
-            } else {
-                this.root.push(new TabStopItem(tabDefs));
-            }
+
+        for (const tabDefinition of tabDefinitions) {
+            this.root.push(new TabStopItem(tabDefinition));
         }
     }
 }
@@ -59,26 +50,14 @@ export class TabAttributes extends XmlAttributeComponent<{
 }
 
 export class TabStopItem extends XmlComponent {
-    public constructor(tabDef: TabStopDefinition | TabStopType, position?: number, leader?: LeaderType) {
+    public constructor({ type, position, leader }: TabStopDefinition) {
         super("w:tab");
-        if (typeof tabDef === "string") {
-            if (typeof position === "number")
-                this.root.push(
-                    new TabAttributes({
-                        val: tabDef,
-                        pos: position,
-                        leader,
-                    }),
-                );
-            else throw Error("Undefined position: " + position);
-        } else {
-            this.root.push(
-                new TabAttributes({
-                    val: tabDef.type,
-                    pos: tabDef.position,
-                    leader: tabDef.leader,
-                }),
-            );
-        }
+        this.root.push(
+            new TabAttributes({
+                val: type,
+                pos: position,
+                leader: leader,
+            }),
+        );
     }
 }

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -9,7 +9,7 @@ import { PageBreakBefore } from "./formatting/break";
 import { IIndentAttributesProperties, Indent } from "./formatting/indent";
 import { ISpacingProperties, Spacing } from "./formatting/spacing";
 import { HeadingLevel, Style } from "./formatting/style";
-import { LeaderType, TabStop, TabStopDefinition, TabStopPosition, TabStopType } from "./formatting/tab-stop";
+import { TabStop, TabStopDefinition, TabStopType } from "./formatting/tab-stop";
 import { NumberProperties } from "./formatting/unordered-list";
 import { FrameProperties, IFrameOptions } from "./frame/frame-properties";
 import { OutlineLevel } from "./links";
@@ -41,11 +41,7 @@ export interface IParagraphPropertiesOptions extends IParagraphStylePropertiesOp
     readonly heading?: HeadingLevel;
     readonly bidirectional?: boolean;
     readonly pageBreakBefore?: boolean;
-    readonly tabStops?: readonly {
-        readonly position: number | TabStopPosition;
-        readonly type: TabStopType;
-        readonly leader?: LeaderType;
-    }[];
+    readonly tabStops?: readonly TabStopDefinition[];
     readonly style?: string;
     readonly bullet?: {
         readonly level: number;
@@ -136,21 +132,14 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
          * FIX: Multitab support for Libre Writer
          * Ensure there is only one w:tabs tag with multiple w:tab
          */
-        let tabDefs: TabStopDefinition[] = [];
-        if (options.rightTabStop) {
-            tabDefs.push({ type: TabStopType.RIGHT, position: options.rightTabStop });
-        }
+        const tabDefinitions: readonly TabStopDefinition[] = [
+            ...(options.rightTabStop ? [{ type: TabStopType.RIGHT, position: options.rightTabStop }] : []),
+            ...(options.tabStops ? options.tabStops : []),
+            ...(options.leftTabStop ? [{ type: TabStopType.LEFT, position: options.leftTabStop }] : []),
+        ];
 
-        if (options.tabStops) {
-            tabDefs = tabDefs.concat(options.tabStops);
-        }
-
-        if (options.leftTabStop) {
-            tabDefs.push({ type: TabStopType.LEFT, position: options.leftTabStop });
-        }
-
-        if (tabDefs.length) {
-            this.push(new TabStop(tabDefs));
+        if (tabDefinitions.length > 0) {
+            this.push(new TabStop(tabDefinitions));
         }
         /**
          *  FIX - END

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -9,7 +9,7 @@ import { PageBreakBefore } from "./formatting/break";
 import { IIndentAttributesProperties, Indent } from "./formatting/indent";
 import { ISpacingProperties, Spacing } from "./formatting/spacing";
 import { HeadingLevel, Style } from "./formatting/style";
-import { LeaderType, TabStop, TabStopPosition, TabStopType } from "./formatting/tab-stop";
+import { LeaderType, TabStop, TabStopDefinition, TabStopPosition, TabStopType } from "./formatting/tab-stop";
 import { NumberProperties } from "./formatting/unordered-list";
 import { FrameProperties, IFrameOptions } from "./frame/frame-properties";
 import { OutlineLevel } from "./links";
@@ -132,19 +132,29 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
             this.push(new Shading(options.shading));
         }
 
+        /**
+         * FIX: Multitab support for Libre Writer
+         * Ensure there is only one w:tabs tag with multiple w:tab
+         */
+        let tabDefs: TabStopDefinition[] = [];
         if (options.rightTabStop) {
-            this.push(new TabStop(TabStopType.RIGHT, options.rightTabStop));
+            tabDefs.push({ type: TabStopType.RIGHT, position: options.rightTabStop});
         }
 
         if (options.tabStops) {
-            for (const tabStop of options.tabStops) {
-                this.push(new TabStop(tabStop.type, tabStop.position, tabStop.leader));
-            }
+            tabDefs = tabDefs.concat(options.tabStops);
         }
 
         if (options.leftTabStop) {
-            this.push(new TabStop(TabStopType.LEFT, options.leftTabStop));
+            tabDefs.push({ type: TabStopType.LEFT, position: options.leftTabStop });
         }
+
+        if (tabDefs.length) {
+            this.push(new TabStop(tabDefs));
+        }
+        /**
+         *  FIX - END 
+         */
 
         if (options.bidirectional !== undefined) {
             this.push(new OnOffElement("w:bidi", options.bidirectional));

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -138,7 +138,7 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
          */
         let tabDefs: TabStopDefinition[] = [];
         if (options.rightTabStop) {
-            tabDefs.push({ type: TabStopType.RIGHT, position: options.rightTabStop});
+            tabDefs.push({ type: TabStopType.RIGHT, position: options.rightTabStop });
         }
 
         if (options.tabStops) {
@@ -153,7 +153,7 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
             this.push(new TabStop(tabDefs));
         }
         /**
-         *  FIX - END 
+         *  FIX - END
          */
 
         if (options.bidirectional !== undefined) {


### PR DESCRIPTION
Have faced issue with tabStop while using docx.js. Turns out docx generates multiple TabStops with single TabStop. This was not supported by LibreOffice.

So I forked and fixed the issue. I am currently using the fork in my project, will test and update if something else comes up.

Cheers,
Ronit R. BK