### PR TITLE
Change `globalObject` to `globalThis`

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,7 +12,7 @@ const configuration = {
         filename: "index.js",
         libraryTarget: "umd",
         library: "docx",
-        globalObject: "this",
+        globalObject: "globalThis",
     },
 
     resolve: {


### PR DESCRIPTION
I want to run docs.js in some embed js engine which have not `this` defined in global namespace (and es module also haven't).

Compatibility: not a problem, `globalThis` was added in ES6, and this project's `tsconfig.json` also uses ES6 target.

https://github.com/dolanmiu/docx/blob/master/tsconfig.json#L3