### PR TITLE
fix: added unique numeric id creator to avoid numbering render errors

### DIFF
--- a/src/file/drawing/anchor/anchor.spec.ts
+++ b/src/file/drawing/anchor/anchor.spec.ts
@@ -41,11 +41,11 @@ const createAnchor = (drawingOptions: IDrawingOptions): Anchor =>
 
 describe("Anchor", () => {
     before(() => {
-        stub(convenienceFunctions, "uniqueNumericId").callsFake(() => 0);
+        stub(convenienceFunctions, "docPropertiesUniqueNumericId").callsFake(() => 0);
     });
 
     after(() => {
-        (convenienceFunctions.uniqueNumericId as SinonStub).restore();
+        (convenienceFunctions.docPropertiesUniqueNumericId as SinonStub).restore();
     });
 
     let anchor: Anchor;

--- a/src/file/drawing/doc-properties/doc-properties.ts
+++ b/src/file/drawing/doc-properties/doc-properties.ts
@@ -2,7 +2,7 @@
 import { IContext, IXmlableObject, NextAttributeComponent, XmlComponent } from "@file/xml-components";
 import { ConcreteHyperlink } from "@file/paragraph";
 
-import { uniqueNumericIdCreator } from "@util/convenience-functions";
+import { docPropertiesUniqueNumericId } from "@util/convenience-functions";
 
 import { createHyperlinkClick } from "./doc-properties-children";
 
@@ -24,8 +24,6 @@ export interface DocPropertiesOptions {
     readonly title: string;
 }
 
-const uniqueNumericId = uniqueNumericIdCreator();
-
 export class DocProperties extends XmlComponent {
     public constructor({ name, description, title }: DocPropertiesOptions = { name: "", description: "", title: "" }) {
         super("wp:docPr");
@@ -34,7 +32,7 @@ export class DocProperties extends XmlComponent {
             new NextAttributeComponent({
                 id: {
                     key: "id",
-                    value: uniqueNumericId(),
+                    value: docPropertiesUniqueNumericId(),
                 },
                 name: {
                     key: "name",

--- a/src/file/drawing/doc-properties/doc-properties.ts
+++ b/src/file/drawing/doc-properties/doc-properties.ts
@@ -2,7 +2,7 @@
 import { IContext, IXmlableObject, NextAttributeComponent, XmlComponent } from "@file/xml-components";
 import { ConcreteHyperlink } from "@file/paragraph";
 
-import { uniqueNumericId } from "@util/convenience-functions";
+import { uniqueNumericIdCreator } from "@util/convenience-functions";
 
 import { createHyperlinkClick } from "./doc-properties-children";
 
@@ -23,6 +23,8 @@ export interface DocPropertiesOptions {
     readonly description: string;
     readonly title: string;
 }
+
+const uniqueNumericId = uniqueNumericIdCreator();
 
 export class DocProperties extends XmlComponent {
     public constructor({ name, description, title }: DocPropertiesOptions = { name: "", description: "", title: "" }) {

--- a/src/file/drawing/drawing.spec.ts
+++ b/src/file/drawing/drawing.spec.ts
@@ -31,11 +31,11 @@ const createDrawing = (drawingOptions?: IDrawingOptions): Drawing =>
 
 describe("Drawing", () => {
     before(() => {
-        stub(convenienceFunctions, "uniqueNumericId").callsFake(() => 0);
+        stub(convenienceFunctions, "docPropertiesUniqueNumericId").callsFake(() => 0);
     });
 
     after(() => {
-        (convenienceFunctions.uniqueNumericId as SinonStub).restore();
+        (convenienceFunctions.docPropertiesUniqueNumericId as SinonStub).restore();
     });
 
     let currentBreak: Drawing;

--- a/src/file/numbering/numbering.spec.ts
+++ b/src/file/numbering/numbering.spec.ts
@@ -8,11 +8,13 @@ import { Numbering } from "./numbering";
 
 describe("Numbering", () => {
     before(() => {
-        stub(convenienceFunctions, "uniqueNumericId").callsFake(() => 0);
+        stub(convenienceFunctions, "abstractNumUniqueNumericId").callsFake(() => 0);
+        stub(convenienceFunctions, "concreteNumUniqueNumericId").callsFake(() => 0);
     });
 
     after(() => {
-        (convenienceFunctions.uniqueNumericId as SinonStub).restore();
+        (convenienceFunctions.abstractNumUniqueNumericId as SinonStub).restore();
+        (convenienceFunctions.concreteNumUniqueNumericId as SinonStub).restore();
     });
 
     describe("#constructor", () => {

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -2,7 +2,7 @@
 // https://stackoverflow.com/questions/58622437/purpose-of-abstractnum-and-numberinginstance
 import { AlignmentType } from "@file/paragraph";
 import { IContext, IXmlableObject, XmlComponent } from "@file/xml-components";
-import { convertInchesToTwip, uniqueNumericIdCreator } from "@util/convenience-functions";
+import { abstractNumUniqueNumericId, concreteNumUniqueNumericId, convertInchesToTwip } from "@util/convenience-functions";
 
 import { DocumentAttributes } from "../document/document-attributes";
 import { AbstractNumbering } from "./abstract-numbering";
@@ -15,9 +15,6 @@ export interface INumberingOptions {
         readonly reference: string;
     }[];
 }
-
-const abstractNumUniqueNumericId = uniqueNumericIdCreator();
-const concreteNumUniqueNumericId = uniqueNumericIdCreator(1); // Setting initial to 1 as we have numId = 1 for "default-bullet-numbering"
 
 // <xsd:element name="numbering" type="CT_Numbering"/>
 //

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -2,7 +2,7 @@
 // https://stackoverflow.com/questions/58622437/purpose-of-abstractnum-and-numberinginstance
 import { AlignmentType } from "@file/paragraph";
 import { IContext, IXmlableObject, XmlComponent } from "@file/xml-components";
-import { convertInchesToTwip, uniqueNumericId } from "@util/convenience-functions";
+import { convertInchesToTwip, uniqueNumericIdCreator } from "@util/convenience-functions";
 
 import { DocumentAttributes } from "../document/document-attributes";
 import { AbstractNumbering } from "./abstract-numbering";
@@ -15,6 +15,9 @@ export interface INumberingOptions {
         readonly reference: string;
     }[];
 }
+
+const abstractNumUniqueNumericId = uniqueNumericIdCreator();
+const concreteNumUniqueNumericId = uniqueNumericIdCreator(1); // Setting initial to 1 as we have numId = 1 for "default-bullet-numbering"
 
 // <xsd:element name="numbering" type="CT_Numbering"/>
 //
@@ -55,7 +58,7 @@ export class Numbering extends XmlComponent {
             }),
         );
 
-        const abstractNumbering = new AbstractNumbering(uniqueNumericId(), [
+        const abstractNumbering = new AbstractNumbering(abstractNumUniqueNumericId(), [
             {
                 level: 0,
                 format: LevelFormat.BULLET,
@@ -176,7 +179,7 @@ export class Numbering extends XmlComponent {
         this.abstractNumberingMap.set("default-bullet-numbering", abstractNumbering);
 
         for (const con of options.config) {
-            this.abstractNumberingMap.set(con.reference, new AbstractNumbering(uniqueNumericId(), con.levels));
+            this.abstractNumberingMap.set(con.reference, new AbstractNumbering(abstractNumUniqueNumericId(), con.levels));
             this.referenceConfigMap.set(con.reference, con.levels);
         }
     }
@@ -209,7 +212,7 @@ export class Numbering extends XmlComponent {
         const firstLevelStartNumber = referenceConfigLevels && referenceConfigLevels[0].start;
 
         const concreteNumberingSettings = {
-            numId: uniqueNumericId(),
+            numId: concreteNumUniqueNumericId(),
             abstractNumId: abstractNumbering.id,
             reference,
             instance,

--- a/src/file/paragraph/links/bookmark.ts
+++ b/src/file/paragraph/links/bookmark.ts
@@ -1,9 +1,11 @@
 // http://officeopenxml.com/WPbookmark.php
 import { XmlComponent } from "@file/xml-components";
-import { uniqueNumericId } from "@util/convenience-functions";
+import { uniqueNumericIdCreator } from "@util/convenience-functions";
 
 import { ParagraphChild } from "../paragraph";
 import { BookmarkEndAttributes, BookmarkStartAttributes } from "./bookmark-attributes";
+
+const uniqueNumericId = uniqueNumericIdCreator();
 
 export class Bookmark {
     public readonly start: BookmarkStart;

--- a/src/file/paragraph/links/bookmark.ts
+++ b/src/file/paragraph/links/bookmark.ts
@@ -1,11 +1,9 @@
 // http://officeopenxml.com/WPbookmark.php
 import { XmlComponent } from "@file/xml-components";
-import { uniqueNumericIdCreator } from "@util/convenience-functions";
+import { bookmarkUniqueNumericId } from "@util/convenience-functions";
 
 import { ParagraphChild } from "../paragraph";
 import { BookmarkEndAttributes, BookmarkStartAttributes } from "./bookmark-attributes";
-
-const uniqueNumericId = uniqueNumericIdCreator();
 
 export class Bookmark {
     public readonly start: BookmarkStart;
@@ -13,7 +11,7 @@ export class Bookmark {
     public readonly end: BookmarkEnd;
 
     public constructor(options: { readonly id: string; readonly children: readonly ParagraphChild[] }) {
-        const linkId = uniqueNumericId();
+        const linkId = bookmarkUniqueNumericId();
 
         this.start = new BookmarkStart(options.id, linkId);
         this.children = options.children;

--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -20,12 +20,12 @@ import { TextRun } from "./run";
 describe("Paragraph", () => {
     before(() => {
         stub(convenienceFunctions, "uniqueId").callsFake(() => "test-unique-id");
-        stub(convenienceFunctions, "uniqueNumericId").callsFake(() => -101);
+        stub(convenienceFunctions, "bookmarkUniqueNumericId").callsFake(() => -101);
     });
 
     after(() => {
         (convenienceFunctions.uniqueId as SinonStub).restore();
-        (convenienceFunctions.uniqueNumericId as SinonStub).restore();
+        (convenienceFunctions.bookmarkUniqueNumericId as SinonStub).restore();
     });
 
     describe("#constructor()", () => {

--- a/src/file/paragraph/run/image-run.spec.ts
+++ b/src/file/paragraph/run/image-run.spec.ts
@@ -11,12 +11,12 @@ import { ImageRun } from "./image-run";
 describe("ImageRun", () => {
     before(() => {
         stub(convenienceFunctions, "uniqueId").callsFake(() => "test-unique-id");
-        stub(convenienceFunctions, "uniqueNumericId").callsFake(() => 0);
+        stub(convenienceFunctions, "docPropertiesUniqueNumericId").callsFake(() => 0);
     });
 
     after(() => {
         (convenienceFunctions.uniqueId as SinonStub).restore();
-        (convenienceFunctions.uniqueNumericId as SinonStub).restore();
+        (convenienceFunctions.docPropertiesUniqueNumericId as SinonStub).restore();
     });
 
     describe("#constructor()", () => {

--- a/src/util/convenience-functions.spec.ts
+++ b/src/util/convenience-functions.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { convertInchesToTwip, convertMillimetersToTwip, uniqueId, uniqueNumericId } from "./convenience-functions";
+import { convertInchesToTwip, convertMillimetersToTwip, uniqueId, uniqueNumericIdCreator } from "./convenience-functions";
 
 describe("Utility", () => {
     describe("#convertMillimetersToTwip", () => {
@@ -17,8 +17,9 @@ describe("Utility", () => {
         });
     });
 
-    describe("#uniqueNumericId", () => {
+    describe("#uniqueNumericIdCreator", () => {
         it("should generate a unique incrementing ID", () => {
+            const uniqueNumericId = uniqueNumericIdCreator();
             expect(uniqueNumericId()).to.not.be.undefined;
         });
     });

--- a/src/util/convenience-functions.ts
+++ b/src/util/convenience-functions.ts
@@ -11,4 +11,9 @@ export const uniqueNumericIdCreator = (initial = 0): (() => number) => {
     return () => ++currentCount;
 };
 
+export const abstractNumUniqueNumericId = uniqueNumericIdCreator();
+export const concreteNumUniqueNumericId = uniqueNumericIdCreator(1); // Setting initial to 1 as we have numId = 1 for "default-bullet-numbering"
+export const docPropertiesUniqueNumericId = uniqueNumericIdCreator();
+export const bookmarkUniqueNumericId = uniqueNumericIdCreator();
+
 export const uniqueId = (): string => nanoid().toLowerCase();

--- a/src/util/convenience-functions.ts
+++ b/src/util/convenience-functions.ts
@@ -1,12 +1,14 @@
 import { nanoid } from "nanoid/non-secure";
 
-let currentCount = 0;
-
 // Twip - twentieths of a point
 export const convertMillimetersToTwip = (millimeters: number): number => Math.floor((millimeters / 25.4) * 72 * 20);
 
 export const convertInchesToTwip = (inches: number): number => Math.floor(inches * 72 * 20);
 
-export const uniqueNumericId = (): number => ++currentCount;
+export const uniqueNumericIdCreator = (initial = 0): (() => number) => {
+    let currentCount = initial;
+
+    return () => ++currentCount;
+};
 
 export const uniqueId = (): string => nanoid().toLowerCase();


### PR DESCRIPTION
There are issues with numbering render in MyOffice. It happens when `concreteNumbering` numIds look like 1,5,6, because we have the same `currentCount` for all numIds. And if `concreteNumbering` numIds are consecutive everything renders correctly.

Resolves #2027 