### PR TITLE
Added style support for noProof option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ My Document.docx
 
 # Temporary folder
 tmp
+
+# Exclude Mac .DS_Store files
+.DS_Store

--- a/src/file/paragraph/run/properties.ts
+++ b/src/file/paragraph/run/properties.ts
@@ -1,3 +1,4 @@
+// https://www.ecma-international.org/wp-content/uploads/ECMA-376-1_5th_edition_december_2016.zip page 297, section 17.3.2.21
 import { BorderElement, IBorderOptions } from "@file/border";
 import { IShadingAttributesProperties, Shading } from "@file/shading";
 import { ChangeAttributes, IChangedAttributesProperties } from "@file/track-revision/track-revision";
@@ -34,6 +35,7 @@ export enum TextEffect {
 }
 
 export interface IRunStylePropertiesOptions {
+    readonly noProof?: boolean;
     readonly bold?: boolean;
     readonly boldComplexScript?: boolean;
     readonly italics?: boolean;
@@ -131,7 +133,9 @@ export class RunProperties extends IgnoreIfEmptyXmlComponent {
         if (!options) {
             return;
         }
-
+        if (options.noProof !== undefined) {
+            this.push(new OnOffElement("w:noProof", options.noProof));
+        }
         if (options.bold !== undefined) {
             this.push(new OnOffElement("w:b", options.bold));
         }

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -18,9 +18,7 @@ describe("Run", () => {
             expect(tree).to.deep.equal({
                 "w:r": [
                     {
-                        "w:rPr": [
-                            { "w:noProof": {} },
-                        ],
+                        "w:rPr": [{ "w:noProof": {} }],
                     },
                 ],
             });
@@ -32,9 +30,7 @@ describe("Run", () => {
         expect(tree).to.deep.equal({
             "w:r": [
                 {
-                    "w:rPr": [
-                        { "w:noProof": { _attr: { "w:val": false } } },
-                    ],
+                    "w:rPr": [{ "w:noProof": { _attr: { "w:val": false } } }],
                 },
             ],
         });

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -9,7 +9,7 @@ import { PageNumber, Run } from "./run";
 import { UnderlineType } from "./underline";
 import { TextEffect } from "./properties";
 describe("Run", () => {
-    describe("#noproof()", () => {
+    describe("#noProof()", () => {
         it("turns off spelling and grammar checkers for a run", () => {
             const run = new Run({
                 noProof: true,

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -8,8 +8,38 @@ import { EmphasisMarkType } from "./emphasis-mark";
 import { PageNumber, Run } from "./run";
 import { UnderlineType } from "./underline";
 import { TextEffect } from "./properties";
-
 describe("Run", () => {
+    describe("#noproof()", () => {
+        it("turns off spelling and grammar checkers for a run", () => {
+            const run = new Run({
+                noProof: true,
+            });
+            const tree = new Formatter().format(run);
+            expect(tree).to.deep.equal({
+                "w:r": [
+                    {
+                        "w:rPr": [
+                            { "w:noProof": {} },
+                        ],
+                    },
+                ],
+            });
+        });
+        const run = new Run({
+            noProof: false,
+        });
+        const tree = new Formatter().format(run);
+        expect(tree).to.deep.equal({
+            "w:r": [
+                {
+                    "w:rPr": [
+                        { "w:noProof": { _attr: { "w:val": false } } },
+                    ],
+                },
+            ],
+        });
+    });
+
     describe("#bold()", () => {
         it("it should add bold to the properties", () => {
             const run = new Run({

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -23,17 +23,6 @@ describe("Run", () => {
                 ],
             });
         });
-        const run = new Run({
-            noProof: false,
-        });
-        const tree = new Formatter().format(run);
-        expect(tree).to.deep.equal({
-            "w:r": [
-                {
-                    "w:rPr": [{ "w:noProof": { _attr: { "w:val": false } } }],
-                },
-            ],
-        });
     });
 
     describe("#bold()", () => {


### PR DESCRIPTION
Useful for blocks of source code, and
possibly other things that cause the grammar
and spelling checkers to go nuts.
Example usage:

```ts
 run: {
    font:"Consolas",
    color: "0000AA",
    break:1,
    noProof:true,
},
```

Also added section to .gitignore to exclude
Mac .DS_Store files. These are useless on
anything other than a Mac.