### PR TITLE
Draft: Unbundle dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,19 +2,12 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import dts from "vite-plugin-dts";
-import { nodePolyfills } from "vite-plugin-node-polyfills";
+import pkg from './package.json';
 
 export default defineConfig({
     plugins: [
         tsconfigPaths(),
         dts(),
-        nodePolyfills({
-            exclude: ["fs"],
-            globals: {
-                Buffer: false,
-            },
-            protocolImports: true,
-        }),
     ],
     resolve: {
         alias: {
@@ -53,6 +46,9 @@ export default defineConfig({
         outDir: resolve(__dirname, "build"),
         commonjsOptions: {
             include: [/node_modules/],
+        },
+        rollupOptions: {
+            external: [...Object.keys(pkg.dependencies || {}), 'stream']
         },
     },
     test: {


### PR DESCRIPTION
Instead of bundling all dependencies into docx's built JS (which is a common approach for browser environments), this lets them be imported through import / require (as is typical with NPM).  This reduces the size of docx's builds from ~711kB each to ~250kB each and avoids duplicating code for applications that are already using dependencies such as jszip.  It also avoids any Node.js polyfills, which is a mixed bag - that prevents problems such as #2237 but leaves it up to users to provide polyfills themselves if using a browser environment.

Code for listing dependencies is based on https://stackoverflow.com/a/74578129/25507