### PR TITLE
changed default section margin from inch to Twip

### DIFF
--- a/src/file/document/body/section-properties/section-properties.ts
+++ b/src/file/document/body/section-properties/section-properties.ts
@@ -5,7 +5,6 @@ import { FooterWrapper } from "@file/footer-wrapper";
 import { HeaderWrapper } from "@file/header-wrapper";
 import { VerticalAlign, VerticalAlignElement } from "@file/vertical-align";
 import { OnOffElement, XmlComponent } from "@file/xml-components";
-import { PositiveUniversalMeasure, UniversalMeasure } from "@util/values";
 
 import { HeaderFooterReference, HeaderFooterReferenceType, HeaderFooterType } from "./properties/header-footer-reference";
 import { Columns, IColumnsAttributes } from "./properties/columns";
@@ -76,10 +75,10 @@ export interface ISectionPropertiesOptions {
 // </xsd:group>
 
 export const sectionMarginDefaults = {
-    TOP: "1in" as UniversalMeasure,
-    RIGHT: "1in" as PositiveUniversalMeasure,
-    BOTTOM: "1in" as UniversalMeasure,
-    LEFT: "1in" as PositiveUniversalMeasure,
+    TOP: 1440,
+    RIGHT: 1440,
+    BOTTOM: 1440,
+    LEFT: 1440,
     HEADER: 708,
     FOOTER: 708,
     GUTTER: 0,


### PR DESCRIPTION
Some wierd word editor cannot interpret imperial units from xml.

This may frustrate new comers, trying to execute samples and fail.

Thus I think default margin value for section should be written in Twip, if no other problems occur.

Also, MS word automatically changes inches into Twip when saving, which may justify this change.

☘