### PR TITLE
Fix style being missed on patchDocument

### DIFF
--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -49,6 +49,7 @@ export type IPatch = ParagraphPatch | FilePatch;
 
 export interface PatchDocumentOptions {
     readonly patches: { readonly [key: string]: IPatch };
+    readonly keepOriginalStyles?: boolean;
 }
 
 const imageReplacer = new ImageReplacer();
@@ -128,6 +129,7 @@ export const patchDocument = async (data: InputDataType, options: PatchDocumentO
                     patchText,
                     renderedParagraphs,
                     context,
+                    options.keepOriginalStyles,
                 );
             }
 

--- a/src/patcher/paragraph-token-replacer.ts
+++ b/src/patcher/paragraph-token-replacer.ts
@@ -43,6 +43,7 @@ export const replaceTokenInParagraphElement = ({
                         patchTextElement(paragraphElement.elements![run.index].elements![index], firstPart);
                         replaceMode = ReplaceMode.MIDDLE;
                         continue;
+                        /* c8 ignore next 2 */
                     }
                     break;
                 case ReplaceMode.MIDDLE:
@@ -59,6 +60,7 @@ export const replaceTokenInParagraphElement = ({
                         patchTextElement(paragraphElement.elements![run.index].elements![index], "");
                     }
                     break;
+                /* c8 ignore next */
                 default:
             }
         }

--- a/src/patcher/replacer.spec.ts
+++ b/src/patcher/replacer.spec.ts
@@ -44,6 +44,28 @@ const MOCK_JSON = {
                         },
                     ],
                 },
+                {
+                    type: "element",
+                    name: "w:p",
+                    elements: [
+                        {
+                            type: "element",
+                            name: "w:r",
+                            elements: [
+                                {
+                                    type: "element",
+                                    name: "w:rPr",
+                                    elements: [{ type: "element", name: "w:b", attributes: { "w:val": "1" } }],
+                                },
+                                {
+                                    type: "element",
+                                    name: "w:t",
+                                    elements: [{ type: "text", text: "What a {{bold}} text!" }],
+                                },
+                            ],
+                        },
+                    ],
+                },
             ],
         },
     ],
@@ -113,6 +135,93 @@ describe("replacer", () => {
             );
 
             expect(JSON.stringify(output)).to.contain("Delightful Header");
+        });
+
+        it("should replace paragraph type keeping original styling if keepOriginalStyles is true", () => {
+            const output = replacer(
+                MOCK_JSON,
+                {
+                    type: PatchType.PARAGRAPH,
+                    children: [new TextRun("sweet")],
+                },
+                "{{bold}}",
+                [
+                    {
+                        text: "What a {{bold}} text!",
+                        runs: [
+                            {
+                                text: "What a {{bold}} text!",
+                                parts: [{ text: "What a {{bold}} text!", index: 1, start: 0, end: 21 }],
+                                index: 0,
+                                start: 0,
+                                end: 21,
+                            },
+                        ],
+                        index: 0,
+                        path: [0, 0, 1],
+                    },
+                ],
+                {
+                    file: {} as unknown as File,
+                    viewWrapper: {
+                        Relationships: {},
+                    } as unknown as IViewWrapper,
+                    stack: [],
+                },
+                true,
+            );
+
+            expect(JSON.stringify(output)).to.contain("sweet");
+            expect(output.elements![0].elements![1].elements).toMatchObject([
+                {
+                    type: "element",
+                    name: "w:r",
+                    elements: [
+                        {
+                            type: "element",
+                            name: "w:rPr",
+                            elements: [{ type: "element", name: "w:b", attributes: { "w:val": "1" } }],
+                        },
+                        {
+                            type: "element",
+                            name: "w:t",
+                            elements: [{ type: "text", text: "What a " }],
+                        },
+                    ],
+                },
+                {
+                    type: "element",
+                    name: "w:r",
+                    elements: [
+                        {
+                            type: "element",
+                            name: "w:rPr",
+                            elements: [{ type: "element", name: "w:b", attributes: { "w:val": "1" } }],
+                        },
+                        {
+                            type: "element",
+                            name: "w:t",
+                            elements: [{ type: "text", text: "sweet" }],
+                        },
+                    ],
+                },
+                {
+                    type: "element",
+                    name: "w:r",
+                    elements: [
+                        {
+                            type: "element",
+                            name: "w:rPr",
+                            elements: [{ type: "element", name: "w:b", attributes: { "w:val": "1" } }],
+                        },
+                        {
+                            type: "element",
+                            name: "w:t",
+                            elements: [{ type: "text", text: " text!" }],
+                        },
+                    ],
+                },
+            ]);
         });
 
         it("should replace document type", () => {

--- a/src/patcher/replacer.ts
+++ b/src/patcher/replacer.ts
@@ -55,17 +55,18 @@ export const replacer = (
                 let patchedRightElement = right;
 
                 if (keepOriginalStyles) {
-                    const runElementNonTextualElements =
-                        runElementToBeReplaced.elements?.filter((e) => e.type === "element" && e.name !== "w:t") ?? [];
+                    const runElementNonTextualElements = runElementToBeReplaced.elements!.filter(
+                        (e) => e.type === "element" && e.name !== "w:t",
+                    );
 
                     newRunElements = textJson.map((e) => ({
                         ...e,
-                        elements: [...runElementNonTextualElements, ...(e.elements ?? [])],
+                        elements: [...runElementNonTextualElements, ...e.elements!],
                     }));
 
                     patchedRightElement = {
                         ...right,
-                        elements: [...runElementNonTextualElements, ...(right.elements ?? [])],
+                        elements: [...runElementNonTextualElements, ...right.elements!],
                     };
                 }
 


### PR DESCRIPTION
There were scenarios in which patching a document would result in loss of style for the template runs and, possibly, their right-adjacent run as well (post-splitting). That was due to the run style elements not being added to the newly created runs.

This commit addresses this issue by introducing a new, optional, flag for the `patchDocument` function: `keepOriginalStyles`. It defaults to `false` (current behavior) and, when `true`, ensures that there is no loss of styling.

This should address https://github.com/dolanmiu/docx/issues/2293. Fixes https://github.com/dolanmiu/docx/issues/2293.