### PR TITLE
fix: #2082 Numbering instance restart number not work since v8.0.0 and work well in v7.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "xml-js": "^1.6.8"
             },
             "devDependencies": {
-                "@esbuild/win32-x64": "^0.18.3",
                 "@types/inquirer": "^9.0.3",
                 "@types/prompt": "^1.1.1",
                 "@types/unzipper": "^0.10.4",
@@ -866,21 +865,6 @@
             ],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.18.14",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.14.tgz",
-            "integrity": "sha512-K0QjGbcskx+gY+qp3v4/940qg8JitpXbdxFhRDA1aYoNaPff88+aEwoq45aqJ+ogpxQxmU0ZTjgnrQD/w8iiUg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
             "os": [
                 "win32"
             ],
@@ -12867,12 +12851,6 @@
             "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
             "dev": true,
             "optional": true
-        },
-        "@esbuild/win32-x64": {
-            "version": "0.18.14",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.14.tgz",
-            "integrity": "sha512-K0QjGbcskx+gY+qp3v4/940qg8JitpXbdxFhRDA1aYoNaPff88+aEwoq45aqJ+ogpxQxmU0ZTjgnrQD/w8iiUg==",
-            "dev": true
         },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     },
     "homepage": "https://docx.js.org",
     "devDependencies": {
-        "@esbuild/win32-x64": "^0.18.3",
         "@types/inquirer": "^9.0.3",
         "@types/prompt": "^1.1.1",
         "@types/unzipper": "^0.10.4",

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -216,7 +216,7 @@ export class Numbering extends XmlComponent {
             abstractNumId: abstractNumbering.id,
             reference,
             instance,
-            overrideLevel:
+            overrideLevels: [
                 firstLevelStartNumber && Number.isInteger(firstLevelStartNumber)
                     ? {
                           num: 0,
@@ -226,6 +226,7 @@ export class Numbering extends XmlComponent {
                           num: 0,
                           start: 1,
                       },
+            ],
         };
 
         this.concreteNumberingMap.set(fullReference, new ConcreteNumbering(concreteNumberingSettings));


### PR DESCRIPTION
Hi, I found this bug #2082 some days ago and I fixed it now.

 With addination info, It caused at commit [29da523](https://github.com/dolanmiu/docx/commit/29da5235798283e55f67e81231a883ac05ba4b67). 

With this commit, I remove `@esbuild/win32-x64` dependency, the reason is  it causes`npm install` failed  in my macbook pro, and it is depended with `esbuild` but not this `docx` package.

The numbering restart count as normaly after I patched the `overrideLevel` option
It is the `29` demo result below :point_down:
![image](https://github.com/dolanmiu/docx/assets/23349958/4fee311a-73f7-4903-a80b-62411973f23a)

I will fix as soon if this pr has any problem.