### PR TITLE
add run options to ParagraphPropertiesOptions

### DIFF
--- a/src/file/paragraph/properties.spec.ts
+++ b/src/file/paragraph/properties.spec.ts
@@ -158,5 +158,37 @@ describe("ParagraphProperties", () => {
                 ],
             });
         });
+
+        it("should create with the run property", () => {
+            const properties = new ParagraphProperties({
+                run: {
+                    size: "10pt",
+                },
+            });
+            const tree = new Formatter().format(properties);
+
+            expect(tree).to.deep.equal({
+                "w:pPr": [
+                    {
+                        "w:rPr": [
+                            {
+                                "w:sz": {
+                                    _attr: {
+                                        "w:val": "10pt",
+                                    },
+                                },
+                            },
+                            {
+                                "w:szCs": {
+                                    _attr: {
+                                        "w:val": "10pt",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
     });
 });

--- a/src/file/paragraph/properties.ts
+++ b/src/file/paragraph/properties.ts
@@ -15,6 +15,7 @@ import { NumberProperties } from "./formatting/unordered-list";
 import { WordWrap } from "./formatting/word-wrap";
 import { FrameProperties, IFrameOptions } from "./frame/frame-properties";
 import { OutlineLevel } from "./links";
+import { IRunOptions, RunProperties } from ".";
 
 export interface ILevelParagraphStylePropertiesOptions {
     readonly alignment?: AlignmentType;
@@ -65,6 +66,10 @@ export interface IParagraphPropertiesOptions extends IParagraphStylePropertiesOp
      * This only works in Microsoft Word. It is not part of the ECMA-376 OOXML standard.
      */
     readonly autoSpaceEastAsianText?: boolean;
+    /**
+     * Reference: ECMA-376, 3rd Edition (June, 2011), Fundamentals and Markup Language Reference § 17.3.1.29.
+     */
+    readonly run?: IRunOptions;
 }
 
 export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
@@ -194,6 +199,10 @@ export class ParagraphProperties extends IgnoreIfEmptyXmlComponent {
 
         if (options.autoSpaceEastAsianText !== undefined) {
             this.push(new OnOffElement("w:autoSpaceDN", options.autoSpaceEastAsianText));
+        }
+
+        if (options.run) {
+            this.push(new RunProperties(options.run));
         }
     }
 


### PR DESCRIPTION
http://officeopenxml.com/WPparagraphProperties.php

Specifies the run properties for the paragraph glyph, which is used to represent the physical location of the paragraph mark. When the mark is formatted, a rPr appears within pPr. The text is then formatted accordingly, except for possible direct text formatting. See [Text - Formatting](http://officeopenxml.com/WPtextFormatting.php).

Reference: ECMA-376, 3rd Edition (June, 2011), Fundamentals and Markup Language Reference § 17.3.1.29.