### PR TITLE
Limit the list of supported highlight colors

### DIFF
--- a/src/file/numbering/abstract-numbering.spec.ts
+++ b/src/file/numbering/abstract-numbering.spec.ts
@@ -4,6 +4,7 @@ import { Formatter } from "@export/formatter";
 
 import { AlignmentType, EmphasisMarkType, TabStopPosition } from "../paragraph";
 import { UnderlineType } from "../paragraph/run/underline";
+import { HighlightColor } from "../paragraph/run/properties";
 import { ShadingType } from "../shading";
 import { AbstractNumbering } from "./abstract-numbering";
 import { LevelFormat, LevelSuffix } from "./level";
@@ -2048,23 +2049,23 @@ describe("AbstractNumbering", () => {
 
             const highlightTests = [
                 {
-                    highlight: "005599",
-                    expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "005599" } } }],
+                    highlight: HighlightColor.YELLOW,
+                    expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "yellow" } } }],
                 },
                 {
-                    highlight: "005599",
+                    highlight: HighlightColor.YELLOW,
                     highlightComplexScript: true,
-                    expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "005599" } } }],
+                    expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "yellow" } } }],
                 },
                 {
-                    highlight: "005599",
+                    highlight: HighlightColor.YELLOW,
                     highlightComplexScript: false,
-                    expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }],
+                    expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }],
                 },
                 {
-                    highlight: "005599",
+                    highlight: HighlightColor.YELLOW,
                     highlightComplexScript: "550099",
-                    expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "550099" } } }],
+                    expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "550099" } } }],
                 },
             ];
             highlightTests.forEach(({ highlight, highlightComplexScript, expected }) => {

--- a/src/file/paragraph/run/properties.ts
+++ b/src/file/paragraph/run/properties.ts
@@ -36,6 +36,33 @@ export const TextEffect = {
     NONE: "none",
 } as const;
 
+/*
+ * http://officeopenxml.com/WPtextShading.php
+ *
+ * Limit the list of supported highlight colors
+ *
+ * */
+
+export const HighlightColor = {
+    BLACK: "black",
+    BLUE: "blue",
+    CYAN: "cyan",
+    DARK_BLUE: "darkBlue",
+    DARK_CYAN: "darkCyan",
+    DARK_GRAY: "darkGray",
+    DARK_GREEN: "darkGreen",
+    DARK_MAGENTA: "darkMagenta",
+    DARK_RED: "darkRed",
+    DARK_YELLOW: "darkYellow",
+    GREEN: "green",
+    LIGHT_GRAY: "lightGray",
+    MAGENTA: "magenta",
+    NONE: "none",
+    RED: "red",
+    WHITE: "white",
+    YELLOW: "yellow",
+} as const;
+
 /* eslint-enable */
 
 export interface IRunStylePropertiesOptions {
@@ -65,7 +92,7 @@ export interface IRunStylePropertiesOptions {
     readonly subScript?: boolean;
     readonly superScript?: boolean;
     readonly font?: string | IFontOptions | IFontAttributesProperties;
-    readonly highlight?: string;
+    readonly highlight?: (typeof HighlightColor)[keyof typeof HighlightColor];
     readonly highlightComplexScript?: boolean | string;
     readonly characterSpacing?: number;
     readonly shading?: IShadingAttributesProperties;

--- a/src/file/paragraph/run/run.spec.ts
+++ b/src/file/paragraph/run/run.spec.ts
@@ -7,7 +7,7 @@ import { ShadingType } from "@file/shading";
 import { EmphasisMarkType } from "./emphasis-mark";
 import { PageNumber, Run } from "./run";
 import { UnderlineType } from "./underline";
-import { TextEffect } from "./properties";
+import { HighlightColor, TextEffect } from "./properties";
 describe("Run", () => {
     describe("#noProof()", () => {
         it("turns off spelling and grammar checkers for a run", () => {
@@ -215,18 +215,18 @@ describe("Run", () => {
     describe("#highlight()", () => {
         it("it should add highlight to the properties", () => {
             const run = new Run({
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
             });
             const tree = new Formatter().format(run);
             expect(tree).to.deep.equal({
                 "w:r": [
                     {
                         "w:rPr": [
-                            { "w:highlight": { _attr: { "w:val": "005599" } } },
+                            { "w:highlight": { _attr: { "w:val": "yellow" } } },
                             {
                                 "w:highlightCs": {
                                     _attr: {
-                                        "w:val": "005599",
+                                        "w:val": "yellow",
                                     },
                                 },
                             },

--- a/src/file/styles/style/character-style.spec.ts
+++ b/src/file/styles/style/character-style.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Formatter } from "@export/formatter";
 import { EmphasisMarkType } from "@file/paragraph/run/emphasis-mark";
 import { UnderlineType } from "@file/paragraph/run/underline";
+import { HighlightColor } from "@file/paragraph/run/properties";
 import { ShadingType } from "@file/shading";
 import { EMPTY_OBJECT } from "@file/xml-components";
 
@@ -728,23 +729,23 @@ describe("CharacterStyle", () => {
 
         const highlightTests = [
             {
-                highlight: "005599",
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "005599" } } }],
+                highlight: HighlightColor.YELLOW,
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "yellow" } } }],
             },
             {
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
                 highlightComplexScript: true,
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "005599" } } }],
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "yellow" } } }],
             },
             {
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
                 highlightComplexScript: false,
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }],
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }],
             },
             {
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
                 highlightComplexScript: "550099",
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "550099" } } }],
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "550099" } } }],
             },
         ];
         highlightTests.forEach(({ highlight, highlightComplexScript, expected }) => {

--- a/src/file/styles/style/paragraph-style.spec.ts
+++ b/src/file/styles/style/paragraph-style.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Formatter } from "@export/formatter";
 import { AlignmentType, EmphasisMarkType, TabStopPosition } from "@file/paragraph";
 import { UnderlineType } from "@file/paragraph/run/underline";
+import { HighlightColor } from "@file/paragraph/run";
 import { ShadingType } from "@file/shading";
 import { EMPTY_OBJECT } from "@file/xml-components";
 
@@ -615,23 +616,23 @@ describe("ParagraphStyle", () => {
 
         const highlightTests = [
             {
-                highlight: "005599",
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "005599" } } }],
+                highlight: HighlightColor.YELLOW,
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "yellow" } } }],
             },
             {
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
                 highlightComplexScript: true,
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "005599" } } }],
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "yellow" } } }],
             },
             {
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
                 highlightComplexScript: false,
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }],
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }],
             },
             {
-                highlight: "005599",
+                highlight: HighlightColor.YELLOW,
                 highlightComplexScript: "550099",
-                expected: [{ "w:highlight": { _attr: { "w:val": "005599" } } }, { "w:highlightCs": { _attr: { "w:val": "550099" } } }],
+                expected: [{ "w:highlight": { _attr: { "w:val": "yellow" } } }, { "w:highlightCs": { _attr: { "w:val": "550099" } } }],
             },
         ];
         highlightTests.forEach(({ highlight, highlightComplexScript, expected }) => {


### PR DESCRIPTION
Since highlight property is limited to a fixed values list I suggest introducing an exported const with this list and restrict the property type as well, since string type is misleading. 