### PR TITLE
Document the 'keepOriginalStyles' options

### DIFF
--- a/docs/usage/patcher.md
+++ b/docs/usage/patcher.md
@@ -35,6 +35,9 @@ interface Patch {
 | type     | `PatchType`                       | Required | `DOCUMENT`, `PARAGRAPH`                                                                                                              |
 | children | `FileChild[] or ParagraphChild[]` | Required | The contents to replace with. A `FileChild` is a `Paragraph` or `Table`, whereas a `ParagraphChild` is typical `Paragraph` children. |
 
+
+The patcher also takes in a `keepOriginalStyles` boolean, which will preserve the styles of the patched text when set to true.
+
 ### How to patch existing document
 
 1. Open your existing word document in your favorite Word Processor


### PR DESCRIPTION
At the moment the 'keepOriginalStyles' option when patching a document, is not in the documentation. I had to look in to the closed github issues to find the option. This pull request make sure people don't go through the same struggle.