### PR TITLE
fix Math class name collision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "docx",
-    "version": "8.5.0",
+    "name": "@seewo-doc/docx",
+    "version": "8.5.0-beta.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "docx",
-            "version": "8.5.0",
+            "name": "@seewo-doc/docx",
+            "version": "8.5.0-beta.1",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "docx",
-    "version": "8.5.0",
+    "name": "@seewo-doc/docx",
+    "version": "8.5.1-beta.1",
     "description": "Easily generate .docx files with JS/TS with a nice declarative API. Works for Node and on the Browser.",
     "type": "module",
     "main": "build/index.umd.js",

--- a/src/file/xml-components/xml-component.ts
+++ b/src/file/xml-components/xml-component.ts
@@ -23,7 +23,8 @@ export abstract class XmlComponent extends BaseXmlComponent {
         context.stack.push(this);
         const children = this.root
             .map((comp) => {
-                if (comp instanceof BaseXmlComponent) {
+                // hack: Math 是 JS 的原声对象，受影响导致正常的 Math Component instanceof BaseXmlComponent 为 false
+                if (comp instanceof BaseXmlComponent || comp.rootKey === "m:oMath") {
                     return comp.prepForXml(context);
                 }
                 return comp;


### PR DESCRIPTION
1. 修复 Math Class 的命名于 JS 关键字冲突导致 NodeJS 构建异常
2. 发布新的 npm 版本