### PR TITLE
Add hyphenation support

### DIFF
--- a/docs/usage/document.md
+++ b/docs/usage/document.md
@@ -22,19 +22,30 @@ const doc = new docx.Document({
 
 ### Full list of options:
 
--   creator
--   description
--   title
--   subject
--   keywords
--   lastModifiedBy
--   revision
--   externalStyles
--   styles
--   numbering
--   footnotes
--   hyperlinks
--   background
+| Property                   | Type                                                     | Notes    |
+| -------------------------- | -------------------------------------------------------- | -------- |
+| sections                   | `ISectionOptions[]`                                      | Optional |
+| title                      | `string`                                                 | Optional |
+| subject                    | `string`                                                 | Optional |
+| creator                    | `string`                                                 | Optional |
+| keywords                   | `string`                                                 | Optional |
+| description                | `string`                                                 | Optional |
+| lastModifiedBy             | `string`                                                 | Optional |
+| revision                   | `number`                                                 | Optional |
+| externalStyles             | `string`                                                 | Optional |
+| styles                     | `IStylesOptions`                                         | Optional |
+| numbering                  | `INumberingOptions`                                      | Optional |
+| comments                   | `ICommentsOptions`                                       | Optional |
+| footnotes                  | `Record<string, { children: Paragraph[] }>`              | Optional |
+| background                 | `IDocumentBackgroundOptions`                             | Optional |
+| features                   | `{ trackRevisions?: boolean;  updateFields?: boolean; }` | Optional |
+| compatabilityModeVersion   | `number`                                                 | Optional |
+| compatibility              | `ICompatibilityOptions`                                  | Optional |
+| customProperties           | ` ICustomPropertyOptions`[]                              | Optional |
+| evenAndOddHeaderAndFooters | `boolean`                                                | Optional |
+| defaultTabStop             | `number`                                                 | Optional |
+| fonts                      | ` FontOptions[]`                                         | Optional |
+| hyphenation                | `IHyphenationOptions`                                    | Optional |
 
 ### Change background color of Document
 

--- a/src/file/core-properties/properties.ts
+++ b/src/file/core-properties/properties.ts
@@ -1,5 +1,6 @@
 import { FontOptions } from "@file/fonts/font-table";
 import { ICommentsOptions } from "@file/paragraph/run/comment-run";
+import { IHyphenationOptions } from "@file/settings";
 import { ICompatibilityOptions } from "@file/settings/compatibility";
 import { StringContainer, XmlComponent } from "@file/xml-components";
 import { dateTimeValue } from "@util/values";
@@ -44,6 +45,7 @@ export type IPropertiesOptions = {
     readonly evenAndOddHeaderAndFooters?: boolean;
     readonly defaultTabStop?: number;
     readonly fonts?: readonly FontOptions[];
+    readonly hyphenation?: IHyphenationOptions;
 };
 
 // <xs:element name="coreProperties" type="CT_CoreProperties"/>

--- a/src/file/document/body/section-properties/properties/line-number.spec.ts
+++ b/src/file/document/body/section-properties/properties/line-number.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { Formatter } from "@export/formatter";
+
+import { createLineNumberType } from "./line-number";
+
+describe("createLineNumberType", () => {
+    it("should work", () => {
+        const textDirection = createLineNumberType({ countBy: 0, start: 0, restart: "newPage", distance: 10 });
+
+        const tree = new Formatter().format(textDirection);
+        expect(tree).to.deep.equal({
+            "w:lnNumType": { _attr: { "w:countBy": 0, "w:start": 0, "w:restart": "newPage", "w:distance": 10 } },
+        });
+    });
+
+    it("should work with string measures for distance", () => {
+        const textDirection = createLineNumberType({ countBy: 0, start: 0, restart: "newPage", distance: "10mm" });
+
+        const tree = new Formatter().format(textDirection);
+        expect(tree).to.deep.equal({
+            "w:lnNumType": { _attr: { "w:countBy": 0, "w:start": 0, "w:restart": "newPage", "w:distance": "10mm" } },
+        });
+    });
+
+    it("should work with blank entries", () => {
+        const textDirection = createLineNumberType({});
+
+        const tree = new Formatter().format(textDirection);
+        expect(tree).to.deep.equal({
+            "w:lnNumType": { _attr: {} },
+        });
+    });
+});

--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -479,4 +479,41 @@ describe("File", () => {
             expect(doc.Styles).to.not.be.undefined;
         });
     });
+
+    describe("#features", () => {
+        it("should work with updateFields", () => {
+            const doc = new File({
+                sections: [],
+                features: {
+                    updateFields: true,
+                },
+            });
+
+            expect(doc.Styles).to.not.be.undefined;
+        });
+
+        it("should work with trackRevisions", () => {
+            const doc = new File({
+                sections: [],
+                features: {
+                    trackRevisions: true,
+                },
+            });
+
+            expect(doc.Styles).to.not.be.undefined;
+        });
+    });
+
+    describe("#hyphenation", () => {
+        it("should work with autoHyphenation", () => {
+            const doc = new File({
+                sections: [],
+                hyphenation: {
+                    autoHyphenation: true,
+                },
+            });
+
+            expect(doc.Styles).to.not.be.undefined;
+        });
+    });
 });

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -85,7 +85,7 @@ export class File {
                 hyphenationZone: options.hyphenation?.hyphenationZone,
                 consecutiveHyphenLimit: options.hyphenation?.consecutiveHyphenLimit,
                 doNotHyphenateCaps: options.hyphenation?.doNotHyphenateCaps,
-            }
+            },
         });
 
         this.media = new Media();

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -80,6 +80,12 @@ export class File {
             trackRevisions: options.features?.trackRevisions,
             updateFields: options.features?.updateFields,
             defaultTabStop: options.defaultTabStop,
+            hyphenation: {
+                autoHyphenation: options.hyphenation?.autoHyphenation,
+                hyphenationZone: options.hyphenation?.hyphenationZone,
+                consecutiveHyphenLimit: options.hyphenation?.consecutiveHyphenLimit,
+                doNotHyphenateCaps: options.hyphenation?.doNotHyphenateCaps,
+            }
         });
 
         this.media = new Media();

--- a/src/file/paragraph/run/properties.ts
+++ b/src/file/paragraph/run/properties.ts
@@ -315,8 +315,6 @@ export class RunProperties extends IgnoreIfEmptyXmlComponent {
         if (options.math) {
             this.push(new OnOffElement("w:oMath", options.math));
         }
-
-
     }
 
     public push(item: XmlComponent): void {

--- a/src/file/paragraph/run/properties.ts
+++ b/src/file/paragraph/run/properties.ts
@@ -315,6 +315,8 @@ export class RunProperties extends IgnoreIfEmptyXmlComponent {
         if (options.math) {
             this.push(new OnOffElement("w:oMath", options.math));
         }
+
+
     }
 
     public push(item: XmlComponent): void {

--- a/src/file/settings/settings.spec.ts
+++ b/src/file/settings/settings.spec.ts
@@ -129,6 +129,75 @@ describe("Settings", () => {
             });
         });
 
+        it("should add autoHyphenation setting", () => {
+            const options = {
+                hyphenation: {
+                    autoHyphenation: true,
+                }
+            };
+
+            const tree = new Formatter().format(new Settings(options));
+            expect(Object.keys(tree)).has.length(1);
+            expect(tree["w:settings"]).to.be.an("array");
+            expect(tree["w:settings"]).to.deep.include({
+                "w:autoHyphenation": {},
+            });
+        });
+
+
+        it("should add doNotHyphenateCaps setting", () => {
+            const options = {
+                hyphenation: {
+                    doNotHyphenateCaps: true,
+                }
+            };
+
+            const tree = new Formatter().format(new Settings(options));
+            expect(Object.keys(tree)).has.length(1);
+            expect(tree["w:settings"]).to.be.an("array");
+            expect(tree["w:settings"]).to.deep.include({
+                "w:doNotHyphenateCaps": {},
+            });
+        });
+
+        it("should add hyphenationZone setting", () => {
+            const options = {
+                hyphenation: {
+                    hyphenationZone: 200,
+                }
+            };
+
+            const tree = new Formatter().format(new Settings(options));
+            expect(Object.keys(tree)).has.length(1);
+            expect(tree["w:settings"]).to.be.an("array");
+            expect(tree["w:settings"]).to.deep.include({
+                "w:hyphenationZone": {
+                    _attr: {
+                        "w:val": 200,
+                    },
+                },
+            });
+        });
+
+        it("should add consecutiveHyphenLimit setting", () => {
+            const options = {
+                hyphenation: {
+                    consecutiveHyphenLimit: 3,
+                }
+            };
+
+            const tree = new Formatter().format(new Settings(options));
+            expect(Object.keys(tree)).has.length(1);
+            expect(tree["w:settings"]).to.be.an("array");
+            expect(tree["w:settings"]).to.deep.include({
+                "w:consecutiveHyphenLimit": {
+                    _attr: {
+                        "w:val": 3,
+                    },
+                },
+            });
+        });
+
         // TODO: Remove when deprecating compatibilityModeVersion
         it("should add compatibility setting with legacy version", () => {
             const settings = new Settings({

--- a/src/file/settings/settings.spec.ts
+++ b/src/file/settings/settings.spec.ts
@@ -133,7 +133,7 @@ describe("Settings", () => {
             const options = {
                 hyphenation: {
                     autoHyphenation: true,
-                }
+                },
             };
 
             const tree = new Formatter().format(new Settings(options));
@@ -144,12 +144,11 @@ describe("Settings", () => {
             });
         });
 
-
         it("should add doNotHyphenateCaps setting", () => {
             const options = {
                 hyphenation: {
                     doNotHyphenateCaps: true,
-                }
+                },
             };
 
             const tree = new Formatter().format(new Settings(options));
@@ -164,7 +163,7 @@ describe("Settings", () => {
             const options = {
                 hyphenation: {
                     hyphenationZone: 200,
-                }
+                },
             };
 
             const tree = new Formatter().format(new Settings(options));
@@ -183,7 +182,7 @@ describe("Settings", () => {
             const options = {
                 hyphenation: {
                     consecutiveHyphenLimit: 3,
-                }
+                },
             };
 
             const tree = new Formatter().format(new Settings(options));

--- a/src/file/settings/settings.ts
+++ b/src/file/settings/settings.ts
@@ -156,7 +156,7 @@ export type ISettingsOptions = {
     readonly hyphenation?: IHyphenationOptions;
 };
 
-export interface IHyphenationOptions {
+export type IHyphenationOptions = {
     /** Specifies whether the application automatically hyphenates words as they are typed in the document. */
     readonly autoHyphenation?: boolean;
     /** Specifies the minimum number of characters at the beginning of a word before a hyphen can be inserted. */
@@ -165,7 +165,7 @@ export interface IHyphenationOptions {
     readonly consecutiveHyphenLimit?: number;
     /** Specifies whether to hyphenate words in all capital letters. */
     readonly doNotHyphenateCaps?: boolean;
-}
+};
 
 export class Settings extends XmlComponent {
     public constructor(options: ISettingsOptions) {

--- a/src/file/settings/settings.ts
+++ b/src/file/settings/settings.ts
@@ -153,7 +153,19 @@ export type ISettingsOptions = {
     readonly updateFields?: boolean;
     readonly compatibility?: ICompatibilityOptions;
     readonly defaultTabStop?: number;
+    readonly hyphenation?: IHyphenationOptions;
 };
+
+export interface IHyphenationOptions {
+    /** Specifies whether the application automatically hyphenates words as they are typed in the document. */
+    readonly autoHyphenation?: boolean;
+    /** Specifies the minimum number of characters at the beginning of a word before a hyphen can be inserted. */
+    readonly hyphenationZone?: number;
+    /** Specifies the maximum number of consecutive lines that can end with a hyphenated word. */
+    readonly consecutiveHyphenLimit?: number;
+    /** Specifies whether to hyphenate words in all capital letters. */
+    readonly doNotHyphenateCaps?: boolean;
+}
 
 export class Settings extends XmlComponent {
     public constructor(options: ISettingsOptions) {
@@ -202,6 +214,26 @@ export class Settings extends XmlComponent {
         // https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_defaultTabStop_topic_ID0EIXSX.html
         if (options.defaultTabStop !== undefined) {
             this.root.push(new NumberValueElement("w:defaultTabStop", options.defaultTabStop));
+        }
+
+        // https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_autoHyphenation_topic_ID0EFUMX.html
+        if (options.hyphenation?.autoHyphenation !== undefined) {
+            this.root.push(new OnOffElement("w:autoHyphenation", options.hyphenation.autoHyphenation));
+        }
+
+        // https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_hyphenationZone_topic_ID0ERI3X.html
+        if (options.hyphenation?.hyphenationZone !== undefined) {
+            this.root.push(new NumberValueElement("w:hyphenationZone", options.hyphenation.hyphenationZone));
+        }
+
+        // https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_consecutiveHyphenLim_topic_ID0EQ6RX.html
+        if (options.hyphenation?.consecutiveHyphenLimit !== undefined) {
+            this.root.push(new NumberValueElement("w:consecutiveHyphenLimit", options.hyphenation.consecutiveHyphenLimit));
+        }
+
+        // https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_doNotHyphenateCaps_topic_ID0EW4XX.html
+        if (options.hyphenation?.doNotHyphenateCaps !== undefined) {
+            this.root.push(new OnOffElement("w:doNotHyphenateCaps", options.hyphenation.doNotHyphenateCaps));
         }
 
         this.root.push(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
-import { configDefaults, defineConfig } from "vitest/config";
 import { resolve } from "path";
-import tsconfigPaths from "vite-tsconfig-paths";
 import dts from "vite-plugin-dts";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
     plugins: [
@@ -65,7 +65,7 @@ export default defineConfig({
             reporter: ["text", "json", "html"],
             thresholds: {
                 statements: 100,
-                branches: 99.35,
+                branches: 99.68,
                 functions: 100,
                 lines: 100,
             },


### PR DESCRIPTION
Unfortunately, hyphenation is a non-optional feature for me for generating print-ready books, and it was sorely missing from the library.

If needed, I might find the time to update the docs with this modifiation.