### PR TITLE
Enable rollupTypes in the vite build configuration.

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,9 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 export default defineConfig({
     plugins: [
         tsconfigPaths(),
-        dts(),
+        dts({
+            rollupTypes: true
+        }),
         nodePolyfills({
             exclude: [],
             globals: {


### PR DESCRIPTION
This resolves issues with in dependent TypeScipt packages that are using moduleResolution: NodeNext Modern ES modules cannot use extensionless relative paths in imports.

Fixes https://github.com/dolanmiu/docx/issues/2635