### PR TITLE
fix: add rel to fontTable

### DIFF
--- a/src/export/packer/next-compiler.ts
+++ b/src/export/packer/next-compiler.ts
@@ -108,13 +108,13 @@ export class Compiler {
                             `media/${mediaData.fileName}`,
                         );
                     });
-                    
+
                     file.Document.Relationships.createRelationship(
                         file.Document.Relationships.RelationshipCount + 1,
                         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable",
                         "fontTable.xml",
                     );
-                    
+
                     return xml(
                         this.formatter.format(file.Document.Relationships, {
                             viewWrapper: file.Document,

--- a/src/export/packer/next-compiler.ts
+++ b/src/export/packer/next-compiler.ts
@@ -108,7 +108,13 @@ export class Compiler {
                             `media/${mediaData.fileName}`,
                         );
                     });
-
+                    
+                    file.Document.Relationships.createRelationship(
+                        file.Document.Relationships.RelationshipCount + 1,
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable",
+                        "fontTable.xml",
+                    );
+                    
                     return xml(
                         this.formatter.format(file.Document.Relationships, {
                             viewWrapper: file.Document,


### PR DESCRIPTION
closes https://github.com/dolanmiu/docx/issues/2521

After this change, I think custom embedded fonts are working.

One feature that still seems to be missing is that docxjs only allows for "regular" fonts to be embedded, i.e. afaik it's not possible to create embeds of different variants like this:

```
<w:embedRegular r:id="rId3" w:fontKey="{ED927D51-56FC-1C41-961F-307024631508}" />
        <w:embedBold r:id="rId4" w:fontKey="{D6B4F25E-1ACA-814F-AD3C-35D85CD7A6D5}" />
        <w:embedItalic r:id="rId5" w:fontKey="{E5B26720-9505-4B41-AB02-5860705B4C01}" />
```