### PR TITLE
Fix replacer error on patches with empty Runs

### DIFF
--- a/src/file/paragraph/run/run.ts
+++ b/src/file/paragraph/run/run.ts
@@ -155,7 +155,7 @@ export class Run extends XmlComponent {
 
                 this.root.push(child);
             }
-        } else if (options.text) {
+        } else if (options.text !== undefined) {
             this.root.push(new Text(options.text));
         }
     }

--- a/src/file/paragraph/run/text-run.spec.ts
+++ b/src/file/paragraph/run/text-run.spec.ts
@@ -16,6 +16,14 @@ describe("TextRun", () => {
                 "w:r": [{ "w:t": [{ _attr: { "xml:space": "preserve" } }, "test"] }],
             });
         });
+
+        it("should add empty text into run", () => {
+            run = new TextRun({ text: "" });
+            const f = new Formatter().format(run);
+            expect(f).to.deep.equal({
+                "w:r": [{ "w:t": [{ _attr: { "xml:space": "preserve" } }, ""] }],
+            });
+        });
     });
 
     describe("#referenceFootnote()", () => {

--- a/src/file/paragraph/run/text-run.ts
+++ b/src/file/paragraph/run/text-run.ts
@@ -1,14 +1,7 @@
 import { IRunOptions, Run } from "./run";
-import { Text } from "./run-components/text";
 
 export class TextRun extends Run {
     public constructor(options: IRunOptions | string) {
-        if (typeof options === "string") {
-            super({});
-            this.root.push(new Text(options));
-            return this;
-        }
-
-        super(options);
+        super(typeof options === "string" ? { text: options } : options);
     }
 }

--- a/src/patcher/replacer.spec.ts
+++ b/src/patcher/replacer.spec.ts
@@ -77,7 +77,7 @@ export const MOCK_JSON = {
 
 describe("replacer", () => {
     describe("replacer", () => {
-        it("should throw an error if nothing is added", () => {
+        it("should return { didFindOccurrence: false } if nothing is added", () => {
             const { didFindOccurrence } = replacer({
                 json: {
                     elements: [],

--- a/src/patcher/replacer.spec.ts
+++ b/src/patcher/replacer.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { IViewWrapper } from "@file/document-wrapper";
 import { File } from "@file/file";
-import { Paragraph, TextRun } from "@file/paragraph";
+import { Paragraph, Run, TextRun } from "@file/paragraph";
 import { IContext } from "@file/xml-components";
 
 import { PatchType } from "./from-docx";
@@ -658,6 +658,94 @@ describe("replacer", () => {
             });
 
             expect(JSON.stringify(element)).to.contain("Lorem ipsum paragraph");
+            expect(didFindOccurrence).toBe(true);
+        });
+
+        it("should handle empty runs in patches", () => {
+            // cspell:disable
+            const { element, didFindOccurrence } = replacer({
+                json: {
+                    elements: [
+                        {
+                            type: "element",
+                            name: "w:hdr",
+                            elements: [
+                                {
+                                    type: "element",
+                                    name: "w:p",
+                                    elements: [
+                                        {
+                                            type: "element",
+                                            name: "w:r",
+                                            elements: [
+                                                { type: "text", text: "\n                        " },
+                                                {
+                                                    type: "element",
+                                                    name: "w:rPr",
+                                                    elements: [
+                                                        { type: "text", text: "\n                            " },
+                                                        {
+                                                            type: "element",
+                                                            name: "w:rFonts",
+                                                            attributes: { "w:eastAsia": "Times New Roman" },
+                                                        },
+                                                        { type: "text", text: "\n                            " },
+                                                        {
+                                                            type: "element",
+                                                            name: "w:kern",
+                                                            attributes: { "w:val": "0" },
+                                                        },
+                                                        { type: "text", text: "\n                            " },
+                                                        {
+                                                            type: "element",
+                                                            name: "w:sz",
+                                                            attributes: { "w:val": "20" },
+                                                        },
+                                                        { type: "text", text: "\n                            " },
+                                                        {
+                                                            type: "element",
+                                                            name: "w:lang",
+                                                            attributes: {
+                                                                "w:val": "en-US",
+                                                                "w:eastAsia": "en-US",
+                                                                "w:bidi": "ar-SA",
+                                                            },
+                                                        },
+                                                        { type: "text", text: "\n                        " },
+                                                    ],
+                                                },
+                                                { type: "text", text: "\n                        " },
+                                                {
+                                                    type: "element",
+                                                    name: "w:t",
+                                                    elements: [{ type: "text", text: "{{empty}}" }],
+                                                },
+                                                { type: "text", text: "\n                    " },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                // cspell:enable
+                patch: {
+                    type: PatchType.PARAGRAPH,
+                    children: [new Paragraph({ children: [new Run({})] })],
+                },
+                patchText: "{{empty}}",
+                context: {
+                    file: {} as unknown as File,
+                    viewWrapper: {
+                        Relationships: {},
+                    } as unknown as IViewWrapper,
+                    stack: [],
+                },
+                keepOriginalStyles: true,
+            });
+
+            expect(JSON.stringify(element)).not.to.contain("{{empty}}");
             expect(didFindOccurrence).toBe(true);
         });
     });

--- a/src/patcher/replacer.spec.ts
+++ b/src/patcher/replacer.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { IViewWrapper } from "@file/document-wrapper";
 import { File } from "@file/file";
-import { Paragraph, Run, TextRun } from "@file/paragraph";
+import { Paragraph, TextRun } from "@file/paragraph";
 import { IContext } from "@file/xml-components";
 
 import { PatchType } from "./from-docx";
@@ -689,28 +689,6 @@ describe("replacer", () => {
                                                             name: "w:rFonts",
                                                             attributes: { "w:eastAsia": "Times New Roman" },
                                                         },
-                                                        { type: "text", text: "\n                            " },
-                                                        {
-                                                            type: "element",
-                                                            name: "w:kern",
-                                                            attributes: { "w:val": "0" },
-                                                        },
-                                                        { type: "text", text: "\n                            " },
-                                                        {
-                                                            type: "element",
-                                                            name: "w:sz",
-                                                            attributes: { "w:val": "20" },
-                                                        },
-                                                        { type: "text", text: "\n                            " },
-                                                        {
-                                                            type: "element",
-                                                            name: "w:lang",
-                                                            attributes: {
-                                                                "w:val": "en-US",
-                                                                "w:eastAsia": "en-US",
-                                                                "w:bidi": "ar-SA",
-                                                            },
-                                                        },
                                                         { type: "text", text: "\n                        " },
                                                     ],
                                                 },
@@ -732,7 +710,7 @@ describe("replacer", () => {
                 // cspell:enable
                 patch: {
                     type: PatchType.PARAGRAPH,
-                    children: [new Paragraph({ children: [new Run({})] })],
+                    children: [new TextRun({})],
                 },
                 patchText: "{{empty}}",
                 context: {

--- a/src/patcher/replacer.ts
+++ b/src/patcher/replacer.ts
@@ -74,7 +74,7 @@ export const replacer = ({
 
                     newRunElements = textJson.map((e) => ({
                         ...e,
-                        elements: [...runElementNonTextualElements, ...e.elements!],
+                        elements: [...runElementNonTextualElements, ...(e.elements ?? [])],
                     }));
 
                     patchedRightElement = {


### PR DESCRIPTION
This PR fixes the error in #2855, which occurs because of two minor issues:

1. `TextRun("")` and `TextRun({ text: "" })` counterintuitively didn't do the same thing. One creates an inner `Text` and one doesn't. This PR changes `TextRun("")`, so that both always create the inner Text.
2. `replacer` didn't handle patches with empty `Run`s. This is also fixed by this PR.

