### PR TITLE
hotfix: AlignmentType Justified typo

### DIFF
--- a/src/file/paragraph/formatting/alignment.ts
+++ b/src/file/paragraph/formatting/alignment.ts
@@ -46,7 +46,7 @@ export const AlignmentType = {
     /** Align Right */
     RIGHT: "right",
     /** Justified */
-    JUSTIFIED: "both",
+    JUSTIFIED: "justified",
 } as const;
 
 export class AlignmentAttributes extends XmlAttributeComponent<{


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/763f63fb-20a3-4432-8ad9-d582e5e7df45)
