### PR TITLE
fix: patchDocument, looks for namspaces more carefully over whole doc…

### DIFF
--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -275,7 +275,16 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
 };
 
 const toXml = (jsonObj: Element): string => {
-    const output = js2xml(jsonObj);
+    const output = js2xml(jsonObj, {
+        attributeValueFn(str) {
+            return String(str)
+                .replace(/&(?!amp;|lt;|gt;|quot;|apos;)/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&apos;");
+        }
+    });
     return output;
 };
 

--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -19,7 +19,7 @@ import { replacer } from "./replacer";
 import { toJson } from "./util";
 
 // eslint-disable-next-line functional/prefer-readonly-type
-export type InputDataType = Buffer | string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream;
+export type InputDataType = Buffer | string | number[] | Uint8Array | ArrayBuffer | Blob | NodeJS.ReadableStream | JSZip;
 
 export const PatchType = {
     DOCUMENT: "file",
@@ -70,7 +70,7 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
     keepOriginalStyles,
     placeholderDelimiters = { start: "{{", end: "}}" } as const,
 }: PatchDocumentOptions<T>): Promise<OutputByType[T]> => {
-    const zipContent = await JSZip.loadAsync(data);
+    const zipContent = data instanceof JSZip ? data : await JSZip.loadAsync(data);
     const contexts = new Map<string, IContext>();
     const file = {
         Media: new Media(),

--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -59,6 +59,7 @@ export type PatchDocumentOptions<T extends PatchDocumentOutputType = PatchDocume
         readonly start: string;
         readonly end: string;
     }>;
+    readonly recursive?: boolean;
 };
 
 const imageReplacer = new ImageReplacer();
@@ -71,6 +72,10 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
     patches,
     keepOriginalStyles,
     placeholderDelimiters = { start: "{{", end: "}}" } as const,
+    /**
+     * Search for occurrences over patched document
+     */
+    recursive = true,
 }: PatchDocumentOptions<T>): Promise<OutputByType[T]> => {
     const zipContent = data instanceof JSZip ? data : await JSZip.loadAsync(data);
     const contexts = new Map<string, IContext>();
@@ -188,7 +193,8 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
                         context,
                         keepOriginalStyles,
                     });
-                    if (!didFindOccurrence) {
+                    // What the reason doing that? Once document is patched - it search over patched json again, that takes too long if patched document has big and deep structure.
+                    if (!recursive || !didFindOccurrence) {
                         break;
                     }
                 }

--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -114,7 +114,6 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
                 // We could check all namespaces from Document, but we'll instead
                 // check only those that may be used by our element types.
 
-                // eslint-disable-next-line functional/immutable-data
                 for (const ns of ["mc", "wp", "r", "w15", "m"] as const) {
                     // eslint-disable-next-line functional/immutable-data
                     document.attributes[`xmlns:${ns}`] = DocumentAttributeNamespaces[ns];

--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -110,12 +110,11 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
 
         if (key === "word/document.xml") {
             const document = json.elements?.find((i) => i.name === "w:document");
-            if (document) {
+            if (document && document.attributes) {
                 // We could check all namespaces from Document, but we'll instead
                 // check only those that may be used by our element types.
 
                 // eslint-disable-next-line functional/immutable-data
-                document.attributes = document.attributes ?? {};
                 for (const ns of ["mc", "wp", "r", "w15", "m"] as const) {
                     // eslint-disable-next-line functional/immutable-data
                     document.attributes[`xmlns:${ns}`] = DocumentAttributeNamespaces[ns];

--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -291,14 +291,13 @@ export const patchDocument = async <T extends PatchDocumentOutputType = PatchDoc
 
 const toXml = (jsonObj: Element): string => {
     const output = js2xml(jsonObj, {
-        attributeValueFn(str) {
-            return String(str)
+        attributeValueFn: (str) =>
+            String(str)
                 .replace(/&(?!amp;|lt;|gt;|quot;|apos;)/g, "&amp;")
                 .replace(/</g, "&lt;")
                 .replace(/>/g, "&gt;")
                 .replace(/"/g, "&quot;")
-                .replace(/'/g, "&apos;");
-        },
+                .replace(/'/g, "&apos;"), // cspell:words apos
     });
     return output;
 };

--- a/src/patcher/patch-detector.ts
+++ b/src/patcher/patch-detector.ts
@@ -10,7 +10,7 @@ type PatchDetectorOptions = {
 
 /** Detects which patches are needed/present in a template */
 export const patchDetector = async ({ data }: PatchDetectorOptions): Promise<readonly string[]> => {
-    const zipContent = await JSZip.loadAsync(data);
+    const zipContent = data instanceof JSZip ? data : await JSZip.loadAsync(data);
     const patches = new Set<string>();
 
     for (const [key, value] of Object.entries(zipContent.files)) {

--- a/src/patcher/traverser.ts
+++ b/src/patcher/traverser.ts
@@ -34,10 +34,9 @@ export const traverse = (node: Element): readonly IRenderedParagraphNode[] => {
 
         if (currentNode.element.name === "w:p") {
             renderedParagraphs = [...renderedParagraphs, renderParagraphNode(currentNode)];
-        } else {
-            // eslint-disable-next-line functional/immutable-data
-            queue.push(...elementsToWrapper(currentNode));
         }
+        // eslint-disable-next-line functional/immutable-data
+        queue.push(...elementsToWrapper(currentNode));
     }
 
     return renderedParagraphs;


### PR DESCRIPTION
…ument

added support of different placeholder brackets, default `{{`: `}}`

extended inputDataType to accept JSZip