### PR TITLE
Add Packer.pack and Packer.toArrayBuffer

### DIFF
--- a/src/export/packer/packer.spec.ts
+++ b/src/export/packer/packer.spec.ts
@@ -187,6 +187,33 @@ describe("Packer", () => {
         });
     });
 
+    describe("#toArrayBuffer()", () => {
+        it("should create a standard docx file", async () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn((Packer as any).compiler, "compile").mockReturnValue({
+                generateAsync: () => vi.fn(),
+            });
+            const str = await Packer.toArrayBuffer(file);
+
+            assert.isDefined(str);
+        });
+
+        it("should handle exception if it throws any", () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn((Packer as any).compiler, "compile").mockImplementation(() => {
+                throw new Error();
+            });
+
+            return Packer.toArrayBuffer(file).catch((error) => {
+                assert.isDefined(error);
+            });
+        });
+
+        afterEach(() => {
+            vi.resetAllMocks();
+        });
+    });
+
     describe("#toStream()", () => {
         it("should create a standard docx file", async () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/export/packer/packer.ts
+++ b/src/export/packer/packer.ts
@@ -1,6 +1,7 @@
 import { Stream } from "stream";
 
 import { File } from "@file/file";
+import { OutputByType, OutputType } from "@util/output-type";
 
 import { Compiler, IXmlifyedFile } from "./next-compiler";
 
@@ -21,64 +22,59 @@ const convertPrettifyType = (
     prettify === true ? PrettifyType.WITH_2_BLANKS : prettify === false ? undefined : prettify;
 
 export class Packer {
-    public static async toString(
+    // eslint-disable-next-line require-await
+    public static async pack<T extends OutputType>(
+        file: File,
+        type: T,
+        prettify?: boolean | (typeof PrettifyType)[keyof typeof PrettifyType],
+        overrides: readonly IXmlifyedFile[] = [],
+    ): Promise<OutputByType[T]> {
+        const zip = this.compiler.compile(file, convertPrettifyType(prettify), overrides);
+        return zip.generateAsync({
+            type,
+            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            compression: "DEFLATE",
+        });
+    }
+
+    public static toString(
         file: File,
         prettify?: boolean | (typeof PrettifyType)[keyof typeof PrettifyType],
         overrides: readonly IXmlifyedFile[] = [],
     ): Promise<string> {
-        const zip = this.compiler.compile(file, convertPrettifyType(prettify), overrides);
-        const zipData = await zip.generateAsync({
-            type: "string",
-            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            compression: "DEFLATE",
-        });
-
-        return zipData;
+        return Packer.pack(file, "string", prettify, overrides);
     }
 
-    public static async toBuffer(
+    public static toBuffer(
         file: File,
         prettify?: boolean | (typeof PrettifyType)[keyof typeof PrettifyType],
         overrides: readonly IXmlifyedFile[] = [],
     ): Promise<Buffer> {
-        const zip = this.compiler.compile(file, convertPrettifyType(prettify), overrides);
-        const zipData = await zip.generateAsync({
-            type: "nodebuffer",
-            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            compression: "DEFLATE",
-        });
-
-        return zipData;
+        return Packer.pack(file, "nodebuffer", prettify, overrides);
     }
 
-    public static async toBase64String(
+    public static toBase64String(
         file: File,
         prettify?: boolean | (typeof PrettifyType)[keyof typeof PrettifyType],
         overrides: readonly IXmlifyedFile[] = [],
     ): Promise<string> {
-        const zip = this.compiler.compile(file, convertPrettifyType(prettify), overrides);
-        const zipData = await zip.generateAsync({
-            type: "base64",
-            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            compression: "DEFLATE",
-        });
-
-        return zipData;
+        return Packer.pack(file, "base64", prettify, overrides);
     }
 
-    public static async toBlob(
+    public static toBlob(
         file: File,
         prettify?: boolean | (typeof PrettifyType)[keyof typeof PrettifyType],
         overrides: readonly IXmlifyedFile[] = [],
     ): Promise<Blob> {
-        const zip = this.compiler.compile(file, convertPrettifyType(prettify), overrides);
-        const zipData = await zip.generateAsync({
-            type: "blob",
-            mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            compression: "DEFLATE",
-        });
+        return Packer.pack(file, "blob", prettify, overrides);
+    }
 
-        return zipData;
+    public static toArrayBuffer(
+        file: File,
+        prettify?: boolean | (typeof PrettifyType)[keyof typeof PrettifyType],
+        overrides: readonly IXmlifyedFile[] = [],
+    ): Promise<ArrayBuffer> {
+        return Packer.pack(file, "arraybuffer", prettify, overrides);
     }
 
     public static toStream(

--- a/src/patcher/from-docx.ts
+++ b/src/patcher/from-docx.ts
@@ -11,6 +11,7 @@ import { ConcreteHyperlink, ExternalHyperlink, ParagraphChild } from "@file/para
 import { TargetModeType } from "@file/relationships/relationship/relationship";
 import { IContext } from "@file/xml-components";
 import { uniqueId } from "@util/convenience-functions";
+import { OutputByType, OutputType } from "@util/output-type";
 
 import { appendContentType } from "./content-types-manager";
 import { appendRelationship, getNextRelationshipIndex } from "./relationship-manager";
@@ -47,21 +48,7 @@ type IHyperlinkRelationshipAddition = {
 
 export type IPatch = ParagraphPatch | FilePatch;
 
-// From JSZip
-type OutputByType = {
-    readonly base64: string;
-    // eslint-disable-next-line id-denylist
-    readonly string: string;
-    readonly text: string;
-    readonly binarystring: string;
-    readonly array: readonly number[];
-    readonly uint8array: Uint8Array;
-    readonly arraybuffer: ArrayBuffer;
-    readonly blob: Blob;
-    readonly nodebuffer: Buffer;
-};
-
-export type PatchDocumentOutputType = keyof OutputByType;
+export type PatchDocumentOutputType = OutputType;
 
 export type PatchDocumentOptions<T extends PatchDocumentOutputType = PatchDocumentOutputType> = {
     readonly outputType: T;

--- a/src/util/output-type.ts
+++ b/src/util/output-type.ts
@@ -1,0 +1,15 @@
+// From JSZip
+export type OutputByType = {
+    readonly base64: string;
+    // eslint-disable-next-line id-denylist
+    readonly string: string;
+    readonly text: string;
+    readonly binarystring: string;
+    readonly array: readonly number[];
+    readonly uint8array: Uint8Array;
+    readonly arraybuffer: ArrayBuffer;
+    readonly blob: Blob;
+    readonly nodebuffer: Buffer;
+};
+
+export type OutputType = keyof OutputByType;

--- a/src/util/output-type.ts
+++ b/src/util/output-type.ts
@@ -1,3 +1,5 @@
+/* v8 ignore start */
+// Simply type definitions. Can ignore testing and coverage
 // From JSZip
 export type OutputByType = {
     readonly base64: string;
@@ -13,3 +15,4 @@ export type OutputByType = {
 };
 
 export type OutputType = keyof OutputByType;
+/* v8 ignore stop */


### PR DESCRIPTION
To mirror patchDocument's outputType parameter.

See https://github.com/dolanmiu/docx/discussions/2920

Quoting from that discussion:

> Suggestion:
>
> * Add a Packer.pack or Packer.to method that takes an outputType parameter.
> * Change the existing Packer.to... methods to use this new method.
> * Optionally, add a Packer.toArrayBuffer method for consistency with the existing Packer.to... methods.

I think I may have explained my suggestion poorly - I was suggesting doing all of the above. This PR is an implementation of that. @dolanmiu, if you'd rather that I _just_ add a `toArrayBuffer` function instead, I'm happy to go that route - just let me know. Thanks!

Specific notes:

* Keeping the current code's behavior of when errors are thrown versus turned into rejected promises required adding an otherwise redundant `async` (see `eslint-disable-next-line require-await`).
* Due to https://github.com/istanbuljs/istanbuljs/issues/547, the output-type.ts file that I extracted shows as having 0% coverage. I can lower the coverage targets or add the `const istanbulFix = '';` workaround from that discussion.