### PR TITLE
fix: correct XML attribute name for after auto-spacing.

### DIFF
--- a/src/file/paragraph/formatting/spacing.ts
+++ b/src/file/paragraph/formatting/spacing.ts
@@ -24,7 +24,7 @@ class SpacingAttributes extends XmlAttributeComponent<ISpacingProperties> {
         line: "w:line",
         lineRule: "w:lineRule",
         beforeAutoSpacing: "w:beforeAutospacing",
-        afterAutoSpacing: "w:afterAutoSpacing",
+        afterAutoSpacing: "w:afterAutospacing",
     };
 }
 


### PR DESCRIPTION
Specifying `true` for `ISpacingProperties.afterAutoSpacing` is not working, but `ISpacingProperties.beforeAutoSpacing` is.

It seems to be caused by an incorrectly cased XML property name.

Local testing shows that this change allows after auto-spacing to be applied correctly.