### PR TITLE
feat: Added NumberedItemReference

### DIFF
--- a/docs/usage/hyperlinks.md
+++ b/docs/usage/hyperlinks.md
@@ -16,12 +16,10 @@ const chapter1 = new Paragraph({
     children: [
         new Bookmark({
             id: "anchorForChapter1",
-            children: [
-                new TextRun("Chapter 1"),
-            ],
+            children: [new TextRun("Chapter 1")],
         }),
     ],
-})
+});
 ```
 
 Then you can create an hyperlink pointing to that bookmark with an `InternalHyperLink`:
@@ -35,19 +33,31 @@ const link = new InternalHyperlink({
         }),
     ],
     anchor: "anchorForChapter1",
-})
+});
 ```
+
+### Page reference
 
 You can also get the page number of the bookmark by creating a page reference to it:
 
 ```ts
 const paragraph = new Paragraph({
-    children: [
-        new TextRun("Chapter 1 can be seen on page "),
-        new PageReference("anchorForChapter1"),
-    ],
+    children: [new TextRun("Chapter 1 can be seen on page "), new PageReference("anchorForChapter1")],
 });
 ```
+
+### Numbered item reference
+
+You can also create cross references for numbered items with `NumberedItemReference`.
+
+```ts
+const paragraph = new Paragraph({
+    children: [new TextRun("See Paragraph "), new NumberedItemReference("anchorForParagraph1", "1.1")],
+});
+```
+
+> [!NOTE]
+> The `NumberedItemReference` currently needs a cached value (in this case `1.1`)
 
 ## External
 
@@ -68,7 +78,6 @@ const paragraph = new Paragraph({
     ],
 });
 ```
-
 
 ## Styling hyperlinks
 

--- a/src/file/paragraph/links/numbered-item-ref.spec.ts
+++ b/src/file/paragraph/links/numbered-item-ref.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { NumberedItemReference, NumberedItemReferenceFormat } from "./numbered-item-ref";
+import { Formatter } from "@export/formatter";
+
+describe("NumberedItemReference", () => {
+    describe("#constructor()", () => {
+        it("should create a numbered item ref without options", () => {
+            const ref = new NumberedItemReference("some_bookmark");
+            const tree = new Formatter().format(ref);
+            expect(tree).to.deep.equal({
+                "w:fldSimple": {
+                    _attr: {
+                        "w:instr": "REF some_bookmark \\h \\w",
+                    },
+                },
+            });
+        });
+
+        it("should create a numbered item ref with hyperlink option disabled", () => {
+            const ref = new NumberedItemReference("some_bookmark", "1", { hyperlink: false });
+            const tree = new Formatter().format(ref);
+            expect(tree).to.deep.equal({
+                "w:fldSimple": [
+                    {
+                        _attr: {
+                            "w:instr": "REF some_bookmark \\w",
+                        },
+                    },
+                    {
+                        "w:r": [
+                            {
+                                "w:t": [
+                                    {
+                                        _attr: {
+                                            "xml:space": "preserve",
+                                        },
+                                    },
+                                    "1",
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it("should create a numbered item ref with referenceFormat option", () => {
+            const ref = new NumberedItemReference("some_bookmark", "1", { referenceFormat: NumberedItemReferenceFormat.RELATIVE });
+            const tree = new Formatter().format(ref);
+            expect(tree).to.deep.equal({
+                "w:fldSimple": [
+                    {
+                        _attr: {
+                            "w:instr": "REF some_bookmark \\h \\r",
+                        },
+                    },
+                    {
+                        "w:r": [
+                            {
+                                "w:t": [
+                                    {
+                                        _attr: {
+                                            "xml:space": "preserve",
+                                        },
+                                    },
+                                    "1",
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it("should be possible to use the none referenceFormat option", () => {
+            const ref = new NumberedItemReference("some_bookmark", "1", { referenceFormat: NumberedItemReferenceFormat.NONE });
+            const tree = new Formatter().format(ref);
+            expect(tree).to.deep.equal({
+                "w:fldSimple": [
+                    {
+                        _attr: {
+                            "w:instr": "REF some_bookmark \\h",
+                        },
+                    },
+                    {
+                        "w:r": [
+                            {
+                                "w:t": [
+                                    {
+                                        _attr: {
+                                            "xml:space": "preserve",
+                                        },
+                                    },
+                                    "1",
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/src/file/paragraph/links/numbered-item-ref.ts
+++ b/src/file/paragraph/links/numbered-item-ref.ts
@@ -1,0 +1,74 @@
+import { SimpleField } from "../run";
+
+// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/7088a8ce-e784-49d4-94b8-cba6ef8fce78
+export enum NumberedItemReferenceFormat {
+    NONE = "none",
+    /**
+     * \r option - inserts the paragraph number of the bookmarked paragraph in relative context, or relative to its position in the numbering scheme
+     */
+    RELATIVE = "relative",
+    /**
+     * \n option - causes the field result to be the paragraph number without trailing periods. No information about prior numbered levels is displayed unless it is included as part of the current level.
+     */
+    NO_CONTEXT = "no_context",
+    /**
+     * \w option - causes the field result to be the entire paragraph number without trailing periods, regardless of the location of the REF field.
+     */
+    FULL_CONTEXT = "full_context",
+}
+
+export interface INumberedItemReferenceOptions {
+    /**
+     * \h option - Creates a hyperlink to the bookmarked paragraph.
+     * @default true
+     */
+    readonly hyperlink?: boolean;
+    /**
+     * which switch to use for the reference format
+     * @default NumberedItemReferenceFormat.FULL_CONTEXT
+     */
+    readonly referenceFormat?: NumberedItemReferenceFormat;
+}
+
+/**
+ * Creates a field/cross reference to a numbered item in the document.
+ */
+export class NumberedItemReference extends SimpleField {
+    public constructor(
+        bookmarkId: string,
+        // TODO: It would be nice if the cached value could be automatically generated
+        /**
+         * The cached value of the field. This is used to display the field result in the document.
+         */
+        cachedValue?: string,
+        options: INumberedItemReferenceOptions = {},
+    ) {
+        const { hyperlink = true, referenceFormat = NumberedItemReferenceFormat.FULL_CONTEXT } = options;
+        const baseInstruction = `REF ${bookmarkId}`;
+
+        const switches = [];
+
+        if (hyperlink) {
+            switches.push("\\h");
+        }
+
+        switch (referenceFormat) {
+            case NumberedItemReferenceFormat.RELATIVE:
+                switches.push("\\r");
+                break;
+            case NumberedItemReferenceFormat.NO_CONTEXT:
+                switches.push("\\n");
+                break;
+            case NumberedItemReferenceFormat.FULL_CONTEXT:
+                switches.push("\\w");
+                break;
+            case NumberedItemReferenceFormat.NONE:
+                // No switch needed
+                break;
+        }
+
+        const instruction = `${baseInstruction} ${switches.join(" ")}`;
+
+        super(instruction, cachedValue);
+    }
+}


### PR DESCRIPTION
This PR adds a `NumberedItemReference` class.

This makes it simpler to make cross reference to a numbered item within the document.

One caveat is that you have to provide a cached value, just as you would with a `SimpleFIeld` I am not sure if there is a way to automate this at the moment.

If you see anything I can do better, please let me know. 

