### PR TITLE
feat: Added TableCellSpacing

### DIFF
--- a/src/file/table/table-cell-spacing.ts
+++ b/src/file/table/table-cell-spacing.ts
@@ -1,0 +1,39 @@
+// http://officeopenxml.com/WPtableCellSpacing.php
+import { NextAttributeComponent, XmlComponent } from "@file/xml-components";
+import { Percentage, UniversalMeasure, measurementOrPercentValue } from "@util/values";
+
+// <xsd:simpleType name="ST_TblCellSpacing">
+//   <xsd:restriction base="xsd:string">
+//     <xsd:enumeration value="nil"/>
+//     <xsd:enumeration value="dxa"/>
+//   </xsd:restriction>
+// </xsd:simpleType>
+
+export const CellSpacingType = {
+    /** Value is in twentieths of a point */
+    DXA: "dxa",
+    /** No (empty) value. */
+    NIL: "nil",
+} as const;
+
+// <xsd:complexType name="CT_TblCellSpacing">
+//     <xsd:attribute name="w" type="ST_MeasurementOrPercent"/>
+//     <xsd:attribute name="type" type="ST_TblCellSpacing"/>
+// </xsd:complexType>
+export type ITableCellSpacingProperties = {
+    readonly value: number | Percentage | UniversalMeasure;
+    readonly type?: (typeof CellSpacingType)[keyof typeof CellSpacingType];
+};
+
+export class TableCellSpacingElement extends XmlComponent {
+    public constructor({ type = CellSpacingType.DXA, value }: ITableCellSpacingProperties) {
+        super("w:tblCellSpacing");
+
+        this.root.push(
+            new NextAttributeComponent<ITableCellSpacingProperties>({
+                type: { key: "w:type", value: type },
+                value: { key: "w:w", value: measurementOrPercentValue(value) },
+            }),
+        );
+    }
+}

--- a/src/file/table/table-properties/table-properties.spec.ts
+++ b/src/file/table/table-properties/table-properties.spec.ts
@@ -7,6 +7,7 @@ import { ShadingType } from "@file/shading";
 import { WidthType } from "../table-width";
 import { TableLayoutType } from "./table-layout";
 import { TableProperties } from "./table-properties";
+import { CellSpacingType } from "../table-cell-spacing";
 
 describe("TableProperties", () => {
     describe("#constructor", () => {
@@ -89,6 +90,19 @@ describe("TableProperties", () => {
             const tree = new Formatter().format(tp);
             expect(tree).to.deep.equal({
                 "w:tblPr": [{ "w:tblLayout": { _attr: { "w:type": "fixed" } } }],
+            });
+        });
+
+        it("should add a table cell spacing property", () => {
+            const tp = new TableProperties({
+                cellSpacing: {
+                    value: 1234,
+                    type: CellSpacingType.DXA,
+                },
+            });
+            const tree = new Formatter().format(tp);
+            expect(tree).to.deep.equal({
+                "w:tblPr": [{ "w:tblCellSpacing": { _attr: { "w:type": "dxa", "w:w": 1234 } } }],
             });
         });
     });

--- a/src/file/table/table-properties/table-properties.ts
+++ b/src/file/table/table-properties/table-properties.ts
@@ -30,6 +30,7 @@ import { ITableBordersOptions, TableBorders } from "./table-borders";
 import { ITableCellMarginOptions, TableCellMargin, TableCellMarginElementType } from "./table-cell-margin";
 import { ITableFloatOptions, TableFloatProperties } from "./table-float-properties";
 import { TableLayout, TableLayoutType } from "./table-layout";
+import { ITableCellSpacingProperties, TableCellSpacingElement } from "../table-cell-spacing";
 
 export type ITablePropertiesOptions = {
     readonly width?: ITableWidthProperties;
@@ -42,6 +43,7 @@ export type ITablePropertiesOptions = {
     readonly alignment?: (typeof AlignmentType)[keyof typeof AlignmentType];
     readonly cellMargin?: ITableCellMarginOptions;
     readonly visuallyRightToLeft?: boolean;
+    readonly cellSpacing?: ITableCellSpacingProperties;
 };
 
 export class TableProperties extends IgnoreIfEmptyXmlComponent {
@@ -86,6 +88,10 @@ export class TableProperties extends IgnoreIfEmptyXmlComponent {
 
         if (options.cellMargin) {
             this.root.push(new TableCellMargin(TableCellMarginElementType.TABLE, options.cellMargin));
+        }
+
+        if (options.cellSpacing) {
+            this.root.push(new TableCellSpacingElement(options.cellSpacing));
         }
     }
 }

--- a/src/file/table/table-row/table-row-properties.spec.ts
+++ b/src/file/table/table-row/table-row-properties.spec.ts
@@ -4,6 +4,7 @@ import { Formatter } from "@export/formatter";
 import { HeightRule } from "@file/table/table-row/table-row-height";
 
 import { TableRowProperties } from "./table-row-properties";
+import { CellSpacingType } from "../table-cell-spacing";
 
 describe("TableRowProperties", () => {
     describe("#constructor", () => {
@@ -59,6 +60,19 @@ describe("TableRowProperties", () => {
             });
             const tree = new Formatter().format(rowProperties);
             expect(tree).to.deep.equal({ "w:trPr": [{ "w:trHeight": { _attr: { "w:val": 100, "w:hRule": "atLeast" } } }] });
+        });
+
+        it("should add a table cell spacing property", () => {
+            const rowProperties = new TableRowProperties({
+                cellSpacing: {
+                    value: 1234,
+                    type: CellSpacingType.DXA,
+                },
+            });
+            const tree = new Formatter().format(rowProperties);
+            expect(tree).to.deep.equal({
+                "w:trPr": [{ "w:tblCellSpacing": { _attr: { "w:type": "dxa", "w:w": 1234 } } }],
+            });
         });
     });
 });

--- a/src/file/table/table-row/table-row-properties.ts
+++ b/src/file/table/table-row/table-row-properties.ts
@@ -31,6 +31,7 @@ import { IgnoreIfEmptyXmlComponent, OnOffElement } from "@file/xml-components";
 import { PositiveUniversalMeasure } from "@util/values";
 
 import { HeightRule, TableRowHeight } from "./table-row-height";
+import { ITableCellSpacingProperties, TableCellSpacingElement } from "../table-cell-spacing";
 
 export type ITableRowPropertiesOptions = {
     readonly cantSplit?: boolean;
@@ -39,6 +40,7 @@ export type ITableRowPropertiesOptions = {
         readonly value: number | PositiveUniversalMeasure;
         readonly rule: (typeof HeightRule)[keyof typeof HeightRule];
     };
+    readonly cellSpacing?: ITableCellSpacingProperties;
 };
 
 export class TableRowProperties extends IgnoreIfEmptyXmlComponent {
@@ -55,6 +57,10 @@ export class TableRowProperties extends IgnoreIfEmptyXmlComponent {
 
         if (options.height) {
             this.root.push(new TableRowHeight(options.height.value, options.height.rule));
+        }
+
+        if (options.cellSpacing) {
+            this.root.push(new TableCellSpacingElement(options.cellSpacing));
         }
     }
 }

--- a/src/file/table/table.ts
+++ b/src/file/table/table.ts
@@ -4,6 +4,7 @@ import { FileChild } from "@file/file-child";
 import { AlignmentType } from "../paragraph";
 import { TableGrid } from "./grid";
 import { TableCell, VerticalMergeType } from "./table-cell";
+import { ITableCellSpacingProperties } from "./table-cell-spacing";
 import { ITableBordersOptions, ITableFloatOptions, TableProperties } from "./table-properties";
 import { ITableCellMarginOptions } from "./table-properties/table-cell-margin";
 import { TableLayoutType } from "./table-properties/table-layout";
@@ -32,6 +33,7 @@ export type ITableOptions = {
     readonly borders?: ITableBordersOptions;
     readonly alignment?: (typeof AlignmentType)[keyof typeof AlignmentType];
     readonly visuallyRightToLeft?: boolean;
+    readonly cellSpacing?: ITableCellSpacingProperties;
 };
 
 export class Table extends FileChild {
@@ -48,6 +50,7 @@ export class Table extends FileChild {
         borders,
         alignment,
         visuallyRightToLeft,
+        cellSpacing,
     }: ITableOptions) {
         super("w:tbl");
 
@@ -62,6 +65,7 @@ export class Table extends FileChild {
                 alignment,
                 cellMargin: margins,
                 visuallyRightToLeft,
+                cellSpacing,
             }),
         );
 


### PR DESCRIPTION
Hi all,

this PR adds the possibility to add cell spacing to tables.

According to docs the spacing can be added to a table itself or a row, both versions are implemented here.
(http://officeopenxml.com/WPtableCellSpacing.php).

Link to the docs has also been added to the files.

Checked with eslint => No conflicts
Ran vitest => All tests passed successfully
Ran build => build was successfull

I also went ahead and copied the dist folder into a different project to validate that the cell spacing is in fact applied (Visuals only checked in word).


If you have any further questions or I missed a step in your contributions guide, please give me a heads up and I'll resolve this.