### PR TITLE
fix: export numbered item reference

### DIFF
--- a/src/file/paragraph/links/index.ts
+++ b/src/file/paragraph/links/index.ts
@@ -1,4 +1,5 @@
 export * from "./hyperlink";
 export * from "./bookmark";
+export * from "./numbered-item-ref";
 export * from "./outline-level";
 export * from "./pageref";

--- a/src/file/paragraph/links/numbered-item-ref.ts
+++ b/src/file/paragraph/links/numbered-item-ref.ts
@@ -1,4 +1,4 @@
-import { SimpleField } from "../run";
+import { SimpleField } from "../run/simple-field";
 
 // https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/7088a8ce-e784-49d4-94b8-cba6ef8fce78
 export enum NumberedItemReferenceFormat {


### PR DESCRIPTION
The `NumberedItemReference` class has not been exported, this PR fixes that