### PR TITLE
Add support for paragraph "between" borders

### DIFF
--- a/docs/usage/paragraph.md
+++ b/docs/usage/paragraph.md
@@ -64,7 +64,7 @@ This is the list of options for a paragraph. A detailed explanation is below:
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [text](#text)                  | `string`                                                                                                            | Optional   |                                                                                                                                                             |
 | [heading](#heading)            | `HeadingLevel`                                                                                                      | Optional   | `HEADING_1`, `HEADING_2`, `HEADING_3`, `HEADING_4`, `HEADING_5`, `HEADING_6`, `TITLE`                                                                       |
-| [border](#border)              | `IBorderOptions`                                                                                                    | Optional   | `top`, `bottom`, `left`, `right`. Each of these are of type IBorderPropertyOptions. Click here for Example                                                  |
+| [border](#border)              | `IBorderOptions`                                                                                                    | Optional   | `top`, `bottom`, `left`, `right`, `between`. Each of these are of type IBorderPropertyOptions. Click here for Example                                                  |
 | [spacing](#spacing)            | `ISpacingProperties`                                                                                                | Optional   | See below for ISpacingProperties                                                                                                                            |
 | [outlineLevel](#outline-level) | `number`                                                                                                            | Optional   |                                                                                                                                                             |
 | alignment                      | `AlignmentType`                                                                                                     | Optional   | `START`, `CENTER`, `END`, `BOTH`, `MEDIUM_KASHIDA`, `DISTRIBUTE`, `NUM_TAB`, `HIGH_KASHIDA`, `LOW_KASHIDA`, `THAI_DISTRIBUTE`, `LEFT`, `RIGHT`, `JUSTIFIED` |
@@ -115,7 +115,7 @@ Add borders to a `Paragraph`. Good for making the `Paragraph` stand out. Border 
 
 #### IBorderPropertyOptions
 
-`top`, `bottom`, `left`, `right` of the border
+`top`, `bottom`, `left`, `right`, `between` of the border
 
 | Property | Type     | Notes    |
 | -------- | -------- | -------- |

--- a/src/file/paragraph/formatting/border.spec.ts
+++ b/src/file/paragraph/formatting/border.spec.ts
@@ -33,6 +33,12 @@ describe("Border", () => {
                     style: BorderStyle.WAVE,
                     size: 8,
                 },
+                between: {
+                    color: "FF0000",
+                    space: 9,
+                    style: BorderStyle.WAVE,
+                    size: 10,
+                },
             });
 
             const tree = new Formatter().format(border);
@@ -75,6 +81,16 @@ describe("Border", () => {
                                 "w:color": "FF0000",
                                 "w:space": 7,
                                 "w:sz": 8,
+                                "w:val": "wave",
+                            },
+                        },
+                    },
+                    {
+                        "w:between": {
+                            _attr: {
+                                "w:color": "FF0000",
+                                "w:space": 9,
+                                "w:sz": 10,
                                 "w:val": "wave",
                             },
                         },

--- a/src/file/paragraph/formatting/border.ts
+++ b/src/file/paragraph/formatting/border.ts
@@ -7,6 +7,7 @@ export type IBordersOptions = {
     readonly bottom?: IBorderOptions;
     readonly left?: IBorderOptions;
     readonly right?: IBorderOptions;
+    readonly between?: IBorderOptions;
 };
 
 export class Border extends IgnoreIfEmptyXmlComponent {
@@ -27,6 +28,10 @@ export class Border extends IgnoreIfEmptyXmlComponent {
 
         if (options.right) {
             this.root.push(new BorderElement("w:right", options.right));
+        }
+
+        if (options.between) {
+            this.root.push(new BorderElement("w:between", options.between));
         }
     }
 }


### PR DESCRIPTION
Add between borders for paragraphs following [http://officeopenxml.com…](http://officeopenxml.com/WPborders.php).

Words creates border islands when paragraphs with similar borders follow each other, removing any borders between them (despite them having bottom and top set), only keeping the top of the first paragraph of the island and the bottom of the last paragraph in the island.

This adds the ability to create inner borders within paragraph islands.
