### PR TITLE
fix: pass characterSet parameter to createRegularFont in font-table.ts

### DIFF
--- a/src/file/fonts/font-table.ts
+++ b/src/file/fonts/font-table.ts
@@ -71,6 +71,7 @@ export const createFontTable = (fonts: readonly FontOptionsWithKey[]): XmlCompon
                 name: font.name,
                 index: i + 1,
                 fontKey: font.fontKey,
+                characterSet: font.characterSet,
             }),
         ),
     });


### PR DESCRIPTION
This fixes an issue where the characterSet parameter was not being passed to createRegularFont when creating font tables, causing the generated Word document's fontTable.xml to be missing the w:charset element.