### PR TITLE
feat(paragraph): add firstLineChars indent support

### DIFF
--- a/docs/usage/paragraph.md
+++ b/docs/usage/paragraph.md
@@ -202,6 +202,19 @@ const paragraph = new Paragraph({
 });
 ```
 
+## Indentation
+
+Use `indent.firstLine` for twips-based indentation, or `indent.firstLineChars` when you want Word to treat the first-line indent as a character count. `firstLineChars` uses hundredths of a character, so `200` means two characters.
+
+```ts
+const paragraph = new Paragraph({
+    text: "First line indented by two characters",
+    indent: {
+        firstLineChars: 200,
+    },
+});
+```
+
 ## Outline Level
 
 **Example:**

--- a/src/file/paragraph/formatting/indent.spec.ts
+++ b/src/file/paragraph/formatting/indent.spec.ts
@@ -13,6 +13,7 @@ describe("Indent", () => {
             right: 10,
             hanging: 10,
             firstLine: 10,
+            firstLineChars: 200,
         });
         const tree = new Formatter().format(indent);
         expect(tree).to.deep.equal({
@@ -21,6 +22,7 @@ describe("Indent", () => {
                     "w:start": 10,
                     "w:end": 10,
                     "w:firstLine": 10,
+                    "w:firstLineChars": 200,
                     "w:hanging": 10,
                     "w:left": 10,
                     "w:right": 10,

--- a/src/file/paragraph/formatting/indent.ts
+++ b/src/file/paragraph/formatting/indent.ts
@@ -9,7 +9,13 @@
  * @module
  */
 import { BuilderElement, type XmlComponent } from "@file/xml-components";
-import { type PositiveUniversalMeasure, type UniversalMeasure, signedTwipsMeasureValue, twipsMeasureValue } from "@util/values";
+import {
+    type PositiveUniversalMeasure,
+    type UniversalMeasure,
+    decimalNumber,
+    signedTwipsMeasureValue,
+    twipsMeasureValue,
+} from "@util/values";
 
 /**
  * Properties for configuring paragraph indentation.
@@ -23,6 +29,7 @@ export type IIndentAttributesProperties = {
     readonly right?: number | UniversalMeasure;
     readonly hanging?: number | PositiveUniversalMeasure;
     readonly firstLine?: number | PositiveUniversalMeasure;
+    readonly firstLineChars?: number;
 };
 
 /**
@@ -50,7 +57,7 @@ export type IIndentAttributesProperties = {
  * </xsd:complexType>
  * ```
  */
-export const createIndent = ({ start, end, left, right, hanging, firstLine }: IIndentAttributesProperties): XmlComponent =>
+export const createIndent = ({ start, end, left, right, hanging, firstLine, firstLineChars }: IIndentAttributesProperties): XmlComponent =>
     new BuilderElement<IIndentAttributesProperties>({
         name: "w:ind",
         attributes: {
@@ -60,5 +67,6 @@ export const createIndent = ({ start, end, left, right, hanging, firstLine }: II
             right: { key: "w:right", value: right === undefined ? undefined : signedTwipsMeasureValue(right) },
             hanging: { key: "w:hanging", value: hanging === undefined ? undefined : twipsMeasureValue(hanging) },
             firstLine: { key: "w:firstLine", value: firstLine === undefined ? undefined : twipsMeasureValue(firstLine) },
+            firstLineChars: { key: "w:firstLineChars", value: firstLineChars === undefined ? undefined : decimalNumber(firstLineChars) },
         },
     });


### PR DESCRIPTION
## Summary
- add firstLineChars to IIndentAttributesProperties
- serialize w:firstLineChars with OOXML decimal number validation
- document the new indent option and cover it with a formatting test

## Why
Some Word layouts need first-line indentation defined in characters rather than twips. OOXML already supports w:firstLineChars, but the current paragraph indent API only exposes twips-based firstLine. This change adds first-class support for character-based first-line indentation without changing existing behavior.

## Validation
- ./node_modules/.bin/vitest run src/file/paragraph/formatting/indent.spec.ts
- ./node_modules/.bin/eslint src/file/paragraph/formatting/indent.ts src/file/paragraph/formatting/indent.spec.ts
- npm run build