### PR TITLE
fix: `paragraphStyles` should not include `w:pStyle`

### DIFF
--- a/src/file/styles/style/paragraph-style.spec.ts
+++ b/src/file/styles/style/paragraph-style.spec.ts
@@ -106,6 +106,43 @@ describe("ParagraphStyle", () => {
             });
         });
 
+        it("should not include w:pStyle for paragraph styles with numbering", () => {
+            const style = new StyleForParagraph({
+                id: "myStyleId",
+                paragraph: {
+                    numbering: {
+                        reference: "test-reference",
+                        level: 0,
+                    },
+                },
+            });
+            const tree = new Formatter().format(style, {
+                file: {
+                    Numbering: {
+                        createConcreteNumberingInstance: (_: string, __: number) => undefined,
+                    },
+                } as never,
+                viewWrapper: {},
+                stack: [],
+            });
+
+            expect(tree).to.deep.equal({
+                "w:style": [
+                    { _attr: { "w:type": "paragraph", "w:styleId": "myStyleId" } },
+                    {
+                        "w:pPr": [
+                            {
+                                "w:numPr": [
+                                    { "w:ilvl": { _attr: { "w:val": 0 } } },
+                                    { "w:numId": { _attr: { "w:val": "{test-reference-0}" } } },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
         it("#center", () => {
             const style = new StyleForParagraph({
                 id: "myStyleId",

--- a/src/file/styles/styles.spec.ts
+++ b/src/file/styles/styles.spec.ts
@@ -43,6 +43,48 @@ describe("Styles", () => {
                 },
             ]);
         });
+        it("should not include w:pStyle inside paragraphStyles paragraph properties", () => {
+            const styles = new Styles({
+                paragraphStyles: [
+                    {
+                        id: "pStyleId",
+                        paragraph: {
+                            numbering: {
+                                reference: "test-reference",
+                                level: 0,
+                            },
+                        },
+                    },
+                ],
+            });
+            const tree = new Formatter().format(styles, {
+                file: {
+                    Numbering: {
+                        createConcreteNumberingInstance: (_: string, __: number) => undefined,
+                    },
+                } as any,
+                viewWrapper: {},
+                stack: [],
+            })["w:styles"].filter((x: any) => !x._attr);
+
+            expect(tree).to.deep.equal([
+                {
+                    "w:style": [
+                        { _attr: { "w:type": "paragraph", "w:styleId": "pStyleId" } },
+                        {
+                            "w:pPr": [
+                                {
+                                    "w:numPr": [
+                                        { "w:ilvl": { _attr: { "w:val": 0 } } },
+                                        { "w:numId": { _attr: { "w:val": "{test-reference-0}" } } },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+        });
     });
 
     describe("#createCharacterStyle", () => {


### PR DESCRIPTION
Currently when `paragraphStyles` has a style with a numbering, a `w:pStyle` tag with `ListParagraph` style is inserted into the paragraph style. This causes weird behavior in microsoft word, where choosing one of the custom styles with numbering always make it fall back to `ListParagraph`.

I am not sure how to fix this in a good way, so I have just added some tests that someone else (or myself if I get the time) can use as a starting point.