### PR TITLE
Fix/bundle types issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "docx",
-    "version": "9.7.0",
+    "version": "9.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "docx",
-            "version": "9.7.0",
+            "version": "9.7.1",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^25.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "xml-js": "^1.6.8"
             },
             "devDependencies": {
+                "@microsoft/api-extractor": "^7.58.7",
                 "@types/inquirer": "^9.0.3",
                 "@types/unzipper": "^0.10.4",
                 "@types/xml": "^1.0.8",
@@ -2039,43 +2040,40 @@
             }
         },
         "node_modules/@microsoft/api-extractor": {
-            "version": "7.57.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.6.tgz",
-            "integrity": "sha512-0rFv/D8Grzw1Mjs2+8NGUR+o4h9LVm5zKRtMeWnpdB5IMJF4TeHCL1zR5LMCIudkOvyvjbhMG5Wjs0B5nqsrRQ==",
+            "version": "7.58.7",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz",
+            "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
-                "@microsoft/api-extractor-model": "7.33.4",
+                "@microsoft/api-extractor-model": "7.33.8",
                 "@microsoft/tsdoc": "~0.16.0",
                 "@microsoft/tsdoc-config": "~0.18.1",
-                "@rushstack/node-core-library": "5.20.3",
-                "@rushstack/rig-package": "0.7.2",
-                "@rushstack/terminal": "0.22.3",
-                "@rushstack/ts-command-line": "5.3.3",
+                "@rushstack/node-core-library": "5.23.1",
+                "@rushstack/rig-package": "0.7.3",
+                "@rushstack/terminal": "0.24.0",
+                "@rushstack/ts-command-line": "5.3.9",
                 "diff": "~8.0.2",
-                "lodash": "~4.17.23",
-                "minimatch": "10.2.1",
+                "minimatch": "10.2.3",
                 "resolve": "~1.22.1",
-                "semver": "~7.5.4",
+                "semver": "~7.7.4",
                 "source-map": "~0.6.1",
-                "typescript": "5.8.2"
+                "typescript": "5.9.3"
             },
             "bin": {
                 "api-extractor": "bin/api-extractor"
             }
         },
         "node_modules/@microsoft/api-extractor-model": {
-            "version": "7.33.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.4.tgz",
-            "integrity": "sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==",
+            "version": "7.33.8",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+            "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "~0.16.0",
                 "@microsoft/tsdoc-config": "~0.18.1",
-                "@rushstack/node-core-library": "5.20.3"
+                "@rushstack/node-core-library": "5.23.1"
             }
         },
         "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
@@ -2083,19 +2081,17 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
             }
         },
         "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
@@ -2103,49 +2099,28 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-            "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+            "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@microsoft/api-extractor/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2153,45 +2128,19 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
-        "node_modules/@microsoft/api-extractor/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@microsoft/tsdoc": {
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
             "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@microsoft/tsdoc-config": {
             "version": "0.18.1",
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
             "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "0.16.0",
                 "ajv": "~8.18.0",
@@ -2204,8 +2153,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2222,8 +2170,7 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.10",
@@ -2943,12 +2890,11 @@
             "dev": true
         },
         "node_modules/@rushstack/node-core-library": {
-            "version": "5.20.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
-            "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
+            "version": "5.23.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+            "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "ajv": "~8.18.0",
                 "ajv-draft-04": "~1.0.0",
@@ -2957,7 +2903,7 @@
                 "import-lazy": "~4.0.0",
                 "jju": "~1.4.0",
                 "resolve": "~1.22.1",
-                "semver": "~7.5.4"
+                "semver": "~7.7.4"
             },
             "peerDependencies": {
                 "@types/node": "*"
@@ -2973,8 +2919,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2991,8 +2936,7 @@
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
             },
@@ -3003,12 +2947,11 @@
             }
         },
         "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -3023,8 +2966,7 @@
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
             "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3034,16 +2976,14 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -3051,30 +2991,12 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@rushstack/node-core-library/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3087,27 +3009,17 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
             }
-        },
-        "node_modules/@rushstack/node-core-library/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/@rushstack/problem-matcher": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
             "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "peerDependencies": {
                 "@types/node": "*"
             },
@@ -3118,40 +3030,24 @@
             }
         },
         "node_modules/@rushstack/rig-package": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.2.tgz",
-            "integrity": "sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+            "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
-                "resolve": "~1.22.1",
-                "strip-json-comments": "~3.1.1"
-            }
-        },
-        "node_modules/@rushstack/rig-package/node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1"
             }
         },
         "node_modules/@rushstack/terminal": {
-            "version": "0.22.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.3.tgz",
-            "integrity": "sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==",
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+            "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
-                "@rushstack/node-core-library": "5.20.3",
+                "@rushstack/node-core-library": "5.23.1",
                 "@rushstack/problem-matcher": "0.2.1",
                 "supports-color": "~8.1.1"
             },
@@ -3169,8 +3065,7 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3180,8 +3075,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3193,14 +3087,13 @@
             }
         },
         "node_modules/@rushstack/ts-command-line": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.3.tgz",
-            "integrity": "sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==",
+            "version": "5.3.9",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz",
+            "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
-                "@rushstack/terminal": "0.22.3",
+                "@rushstack/terminal": "0.24.0",
                 "@types/argparse": "1.0.38",
                 "argparse": "~1.0.9",
                 "string-argv": "~0.3.1"
@@ -3324,8 +3217,7 @@
             "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
             "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -4660,8 +4552,7 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -4675,12 +4566,11 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -4697,8 +4587,7 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/ansi-align": {
             "version": "3.0.1",
@@ -4766,8 +4655,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -6456,8 +6344,6 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
             "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -7977,9 +7863,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -7991,8 +7877,7 @@
                     "url": "https://opencollective.com/fastify"
                 }
             ],
-            "optional": true,
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/fast-wrap-ansi": {
             "version": "0.2.2",
@@ -9687,8 +9572,7 @@
             "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
             "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/js-tokens": {
             "version": "10.0.0",
@@ -10233,14 +10117,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -12348,8 +12224,6 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12380,8 +12254,7 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/stable-hash-x": {
             "version": "0.1.1",
@@ -12492,8 +12365,7 @@
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
             "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6.19"
             }
@@ -16218,127 +16090,80 @@
             }
         },
         "@microsoft/api-extractor": {
-            "version": "7.57.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.6.tgz",
-            "integrity": "sha512-0rFv/D8Grzw1Mjs2+8NGUR+o4h9LVm5zKRtMeWnpdB5IMJF4TeHCL1zR5LMCIudkOvyvjbhMG5Wjs0B5nqsrRQ==",
+            "version": "7.58.7",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz",
+            "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
-                "@microsoft/api-extractor-model": "7.33.4",
+                "@microsoft/api-extractor-model": "7.33.8",
                 "@microsoft/tsdoc": "~0.16.0",
                 "@microsoft/tsdoc-config": "~0.18.1",
-                "@rushstack/node-core-library": "5.20.3",
-                "@rushstack/rig-package": "0.7.2",
-                "@rushstack/terminal": "0.22.3",
-                "@rushstack/ts-command-line": "5.3.3",
+                "@rushstack/node-core-library": "5.23.1",
+                "@rushstack/rig-package": "0.7.3",
+                "@rushstack/terminal": "0.24.0",
+                "@rushstack/ts-command-line": "5.3.9",
                 "diff": "~8.0.2",
-                "lodash": "~4.17.23",
-                "minimatch": "10.2.1",
+                "minimatch": "10.2.3",
                 "resolve": "~1.22.1",
-                "semver": "~7.5.4",
+                "semver": "~7.7.4",
                 "source-map": "~0.6.1",
-                "typescript": "5.8.2"
+                "typescript": "5.9.3"
             },
             "dependencies": {
                 "balanced-match": {
                     "version": "4.0.4",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
                     "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 },
                 "brace-expansion": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-                    "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+                    "version": "5.0.6",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+                    "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "balanced-match": "^4.0.2"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "minimatch": {
-                    "version": "10.2.1",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-                    "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+                    "version": "10.2.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+                    "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "brace-expansion": "^5.0.2"
                     }
                 },
                 "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "typescript": {
-                    "version": "5.8.2",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-                    "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+                    "dev": true
                 }
             }
         },
         "@microsoft/api-extractor-model": {
-            "version": "7.33.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.4.tgz",
-            "integrity": "sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==",
+            "version": "7.33.8",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+            "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
                 "@microsoft/tsdoc": "~0.16.0",
                 "@microsoft/tsdoc-config": "~0.18.1",
-                "@rushstack/node-core-library": "5.20.3"
+                "@rushstack/node-core-library": "5.23.1"
             }
         },
         "@microsoft/tsdoc": {
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
             "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "@microsoft/tsdoc-config": {
             "version": "0.18.1",
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
             "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
                 "@microsoft/tsdoc": "0.16.0",
                 "ajv": "~8.18.0",
@@ -16351,8 +16176,6 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
                     "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -16364,9 +16187,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -16769,12 +16590,10 @@
             "dev": true
         },
         "@rushstack/node-core-library": {
-            "version": "5.20.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
-            "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
+            "version": "5.23.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+            "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
                 "ajv": "~8.18.0",
                 "ajv-draft-04": "~1.0.0",
@@ -16783,7 +16602,7 @@
                 "import-lazy": "~4.0.0",
                 "jju": "~1.4.0",
                 "resolve": "~1.22.1",
-                "semver": "~7.5.4"
+                "semver": "~7.7.4"
             },
             "dependencies": {
                 "ajv": {
@@ -16791,8 +16610,6 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
                     "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -16805,17 +16622,13 @@
                     "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
                     "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {}
                 },
                 "fs-extra": {
-                    "version": "11.3.3",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-                    "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+                    "version": "11.3.5",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+                    "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
@@ -16826,67 +16639,35 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
                     "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 },
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 },
                 "jsonfile": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-                    "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+                    "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "graceful-fs": "^4.1.6",
                         "universalify": "^2.0.0"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+                    "dev": true
                 },
                 "universalify": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
                     "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -16895,41 +16676,25 @@
             "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
             "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {}
         },
         "@rushstack/rig-package": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.2.tgz",
-            "integrity": "sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+            "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
-                "resolve": "~1.22.1",
-                "strip-json-comments": "~3.1.1"
-            },
-            "dependencies": {
-                "strip-json-comments": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-                    "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
-                }
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1"
             }
         },
         "@rushstack/terminal": {
-            "version": "0.22.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.3.tgz",
-            "integrity": "sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==",
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+            "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
-                "@rushstack/node-core-library": "5.20.3",
+                "@rushstack/node-core-library": "5.23.1",
                 "@rushstack/problem-matcher": "0.2.1",
                 "supports-color": "~8.1.1"
             },
@@ -16938,17 +16703,13 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "8.1.1",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
                     "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -16956,14 +16717,12 @@
             }
         },
         "@rushstack/ts-command-line": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.3.tgz",
-            "integrity": "sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==",
+            "version": "5.3.9",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz",
+            "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
-                "@rushstack/terminal": "0.22.3",
+                "@rushstack/terminal": "0.24.0",
                 "@types/argparse": "1.0.38",
                 "argparse": "~1.0.9",
                 "string-argv": "~0.3.1"
@@ -17066,9 +16825,7 @@
             "version": "1.0.38",
             "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
             "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "@types/chai": {
             "version": "5.2.3",
@@ -17903,19 +17660,15 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
                 "ajv": "^8.0.0"
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.18.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-                    "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+                    "version": "8.20.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+                    "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -17927,9 +17680,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -17984,8 +17735,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -19227,9 +18976,7 @@
             "version": "8.0.3",
             "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
             "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -20353,12 +20100,10 @@
             }
         },
         "fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "dev": true
         },
         "fast-wrap-ansi": {
             "version": "0.2.2",
@@ -21487,9 +21232,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
             "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "js-tokens": {
             "version": "10.0.0",
@@ -21818,14 +21561,6 @@
             "requires": {
                 "p-locate": "^4.1.0"
             }
-        },
-        "lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -23371,9 +23106,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "source-map-js": {
             "version": "1.2.1",
@@ -23397,9 +23130,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "stable-hash-x": {
             "version": "0.1.1",
@@ -23495,9 +23226,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
             "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "string-width": {
             "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "docx",
-    "version": "9.7.0",
+    "version": "9.7.1",
     "description": "Easily generate .docx files with JS/TS with a nice declarative API. Works for Node and on the Browser.",
     "type": "module",
     "main": "dist/index.umd.cjs",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     },
     "homepage": "https://docx.js.org",
     "devDependencies": {
+        "@microsoft/api-extractor": "^7.58.7",
         "@types/inquirer": "^9.0.3",
         "@types/unzipper": "^0.10.4",
         "@types/xml": "^1.0.8",


### PR DESCRIPTION
Fixes https://github.com/dolanmiu/docx/issues/3453

## Summary
- `vite-plugin-dts` v5 lists `@microsoft/api-extractor` as an optional peer dependency. Without it explicitly installed, `bundleTypes: true` silently falls back to emitting 580+ individual `.d.ts` files with extensionless relative imports — breaking `moduleResolution: NodeNext / Node16`.
- Added `@microsoft/api-extractor` as an explicit devDependency to guarantee the single bundled `index.d.ts` output (matching 9.6.1 behavior).

## Problem
After the 9.7.0 upgrade (`vite-plugin-dts` v4 → v5, `rollupTypes` → `bundleTypes`), users with `moduleResolution: NodeNext` get TS2834 errors ("no exported member") because TypeScript requires explicit `.js` extensions on relative imports in ESM.

## Fix
Adding `@microsoft/api-extractor` ensures `bundleTypes: true` works as intended, producing a single `index.d.ts` with all types inlined and no relative imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version released (9.7.1)
  * Updated development dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dolanmiu/docx/pull/3456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->