### PR TITLE
fix: de-duplicate built-in styles overridden by externalStyles (#3422)

### DIFF
--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -546,6 +546,37 @@ describe("File", () => {
 
             expect(doc.Styles).to.not.be.undefined;
         });
+
+        it("should not duplicate docDefaults or styleIds that the external styles override (#3422)", () => {
+            const doc = new File({
+                sections: [],
+                externalStyles: `
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:docDefaults>
+                            <w:rPrDefault><w:rPr><w:sz w:val="20"/></w:rPr></w:rPrDefault>
+                        </w:docDefaults>
+                        <w:style w:type="paragraph" w:styleId="Title">
+                            <w:name w:val="Custom Title"/>
+                            <w:rPr><w:sz w:val="72"/></w:rPr>
+                        </w:style>
+                    </w:styles>`,
+            });
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const styles: readonly any[] = (new Formatter().format(doc.Styles) as any)["w:styles"];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const stylesWithId = (id: string): readonly any[] =>
+                styles.filter((element) => Array.isArray(element["w:style"]) && element["w:style"][0]?._attr?.["w:styleId"] === id);
+
+            // The external docDefaults and Title replace the built-in ones instead of being appended alongside them.
+            expect(styles.filter((element) => element["w:docDefaults"] !== undefined)).to.have.length(1);
+            expect(stylesWithId("Title")).to.have.length(1);
+            // The surviving Title is the external one, not the built-in (which is named "Title", not "Custom Title").
+            expect(JSON.stringify(stylesWithId("Title")[0])).to.contain("Custom Title");
+            // Built-in defaults that the external styles do NOT override are still present.
+            expect(stylesWithId("Heading2")).to.have.length(1);
+        });
     });
 
     describe("#features", () => {

--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -577,6 +577,60 @@ describe("File", () => {
             // Built-in defaults that the external styles do NOT override are still present.
             expect(stylesWithId("Heading2")).to.have.length(1);
         });
+
+        it("should keep the built-in docDefaults when the external styles omit their own (#3422)", () => {
+            const doc = new File({
+                sections: [],
+                externalStyles: `
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:style w:type="paragraph" w:styleId="Title">
+                            <w:name w:val="Custom Title"/>
+                        </w:style>
+                    </w:styles>`,
+            });
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const styles: readonly any[] = (new Formatter().format(doc.Styles) as any)["w:styles"];
+
+            // Without external docDefaults, the built-in docDefaults must survive (exactly one, not dropped).
+            expect(styles.filter((element) => element["w:docDefaults"] !== undefined)).to.have.length(1);
+        });
+
+        it("should replace every overridden built-in style while adding unknown external ids (#3422)", () => {
+            const doc = new File({
+                sections: [],
+                externalStyles: `
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:style w:type="paragraph" w:styleId="Title">
+                            <w:name w:val="Custom Title"/>
+                        </w:style>
+                        <w:style w:type="paragraph" w:styleId="Heading1">
+                            <w:name w:val="Custom Heading 1"/>
+                        </w:style>
+                        <w:style w:type="paragraph" w:styleId="MyCustomStyle">
+                            <w:name w:val="My Custom Style"/>
+                        </w:style>
+                    </w:styles>`,
+            });
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const styles: readonly any[] = (new Formatter().format(doc.Styles) as any)["w:styles"];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const stylesWithId = (id: string): readonly any[] =>
+                styles.filter((element) => Array.isArray(element["w:style"]) && element["w:style"][0]?._attr?.["w:styleId"] === id);
+
+            // Both overridden built-ins collapse to their single external replacement.
+            expect(stylesWithId("Title")).to.have.length(1);
+            expect(JSON.stringify(stylesWithId("Title")[0])).to.contain("Custom Title");
+            expect(stylesWithId("Heading1")).to.have.length(1);
+            expect(JSON.stringify(stylesWithId("Heading1")[0])).to.contain("Custom Heading 1");
+            // An external style with no built-in counterpart is added, removing nothing.
+            expect(stylesWithId("MyCustomStyle")).to.have.length(1);
+            // Unrelated built-ins are untouched.
+            expect(stylesWithId("Heading2")).to.have.length(1);
+        });
     });
 
     describe("#features", () => {

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -220,7 +220,7 @@ export class File {
             // External styles win: drop any built-in default the external styles already provide. Otherwise the
             // merged styles.xml carries duplicate `w:docDefaults`/`w:styleId` (invalid OOXML, and Word applies the
             // built-in one, silently clobbering the user's style). See dolanmiu/docx#3422.
-            const deduplicatedDefaultStyles = (defaultStyles.importedStyles ?? []).filter((style) => {
+            const deduplicatedDefaultStyles = defaultStyles.importedStyles!.filter((style) => {
                 if (hasDocDefaults && style instanceof DocumentDefaults) {
                     return false;
                 }
@@ -229,7 +229,7 @@ export class File {
 
             this.styles = new Styles({
                 ...externalStyles,
-                importedStyles: [...deduplicatedDefaultStyles, ...(externalStyles.importedStyles ?? [])],
+                importedStyles: [...deduplicatedDefaultStyles, ...externalStyles.importedStyles!],
             });
         } else if (options.styles) {
             const stylesFactory = new DefaultStylesFactory();

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -26,8 +26,10 @@ import { CommentsExtended } from "./paragraph/run/comments-extended";
 import { Relationships } from "./relationships";
 import { Settings } from "./settings";
 import { Styles } from "./styles";
+import { DocumentDefaults } from "./styles/defaults/document-defaults";
 import { ExternalStylesFactory } from "./styles/external-styles-factory";
 import { DefaultStylesFactory } from "./styles/factory";
+import { Style } from "./styles/style/style";
 
 /**
  * Options for a document section.
@@ -212,10 +214,22 @@ export class File {
             const defaultFactory = new DefaultStylesFactory();
             const defaultStyles = defaultFactory.newInstance(options.styles?.default);
             const externalFactory = new ExternalStylesFactory();
-            const externalStyles = externalFactory.newInstance(options.externalStyles);
+            const { externalStyleIds, hasDocDefaults, ...externalStyles } = externalFactory.newInstance(options.externalStyles);
+            const externalStyleIdSet = new Set(externalStyleIds);
+
+            // External styles win: drop any built-in default the external styles already provide. Otherwise the
+            // merged styles.xml carries duplicate `w:docDefaults`/`w:styleId` (invalid OOXML, and Word applies the
+            // built-in one, silently clobbering the user's style). See dolanmiu/docx#3422.
+            const deduplicatedDefaultStyles = (defaultStyles.importedStyles ?? []).filter((style) => {
+                if (hasDocDefaults && style instanceof DocumentDefaults) {
+                    return false;
+                }
+                return !(style instanceof Style && style.styleId !== undefined && externalStyleIdSet.has(style.styleId));
+            });
+
             this.styles = new Styles({
                 ...externalStyles,
-                importedStyles: [...defaultStyles.importedStyles!, ...externalStyles.importedStyles!],
+                importedStyles: [...deduplicatedDefaultStyles, ...(externalStyles.importedStyles ?? [])],
             });
         } else if (options.styles) {
             const stylesFactory = new DefaultStylesFactory();

--- a/src/file/styles/external-styles-factory.ts
+++ b/src/file/styles/external-styles-factory.ts
@@ -14,6 +14,19 @@ import { ImportedRootElementAttributes, type ImportedXmlComponent, convertToXmlC
 import type { IStylesOptions } from "./styles";
 
 /**
+ * Result of parsing external styles.
+ *
+ * Extends {@link IStylesOptions} with the identities needed to de-duplicate the
+ * imported styles against the library's built-in default styles.
+ */
+export type IExternalStylesResult = IStylesOptions & {
+    /** The `w:styleId`s declared by the external styles. */
+    readonly externalStyleIds: readonly string[];
+    /** Whether the external styles declare their own `w:docDefaults`. */
+    readonly hasDocDefaults: boolean;
+};
+
+/**
  * Factory for creating styles from external XML sources.
  *
  * This factory parses styles from XML (typically from a styles.xml file)
@@ -53,7 +66,7 @@ export class ExternalStylesFactory {
      * @returns Styles object containing all parsed styles
      * @throws Error if styles element cannot be found in the XML
      */
-    public newInstance(xmlData: string): IStylesOptions {
+    public newInstance(xmlData: string): IExternalStylesResult {
         const xmlObj = xml2js(xmlData, { compact: false }) as XMLElement;
 
         let stylesXmlElement: XMLElement | undefined;
@@ -68,9 +81,16 @@ export class ExternalStylesFactory {
 
         const stylesElements = stylesXmlElement.elements || [];
 
+        const externalStyleIds = stylesElements
+            .filter((childElm) => childElm.name === "w:style" && childElm.attributes?.["w:styleId"] !== undefined)
+            .map((childElm) => String(childElm.attributes!["w:styleId"]));
+        const hasDocDefaults = stylesElements.some((childElm) => childElm.name === "w:docDefaults");
+
         return {
             initialStyles: new ImportedRootElementAttributes(stylesXmlElement.attributes),
             importedStyles: stylesElements.map((childElm) => convertToXmlComponent(childElm) as ImportedXmlComponent),
+            externalStyleIds,
+            hasDocDefaults,
         };
     }
 }

--- a/src/file/styles/style/style.ts
+++ b/src/file/styles/style/style.ts
@@ -161,8 +161,12 @@ class StyleAttributes extends XmlAttributeComponent<IStyleAttributes> {
  * ```
  */
 export class Style extends XmlComponent {
+    /** The `w:styleId` of this style, exposed so callers can de-duplicate styles by id. */
+    public readonly styleId?: string;
+
     public constructor(attributes: IStyleAttributes, options: IStyleOptions) {
         super("w:style");
+        this.styleId = attributes.styleId;
         this.root.push(new StyleAttributes(attributes));
         if (options.name) {
             this.root.push(new Name(options.name));


### PR DESCRIPTION
Fixes #3422.

When `externalStyles` is set, `File` concatenates the built-in default styles ahead of the imported ones with no de-duplication:

```ts
importedStyles: [...defaultStyles.importedStyles!, ...externalStyles.importedStyles!]
```

So if the external XML redefines a built-in id, `word/styles.xml` ends up with duplicate `w:docDefaults` / `w:styleId` (e.g. two `Title`). That is invalid OOXML, and Word applies the built-in one (it's emitted first), so the user's custom style is silently dropped.

This makes the external styles win instead: before merging, any built-in default whose `w:styleId` (or `w:docDefaults`) is also declared by the external styles is removed.

- `Style` now exposes its `styleId`
- `ExternalStylesFactory` reports the ids / `docDefaults` declared by the external XML
- `File` filters the colliding defaults, then appends the external ones

Defaults that aren't overridden (e.g. `Heading2` when only `Title` is provided) are kept.

Added a regression test in `file.spec.ts` (one `w:docDefaults`, one `Title`, the surviving `Title` is the external one, non-overridden defaults preserved). The full test suite passes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External Word styles with matching identifiers now replace the corresponding built-in styles (avoiding duplicates).
  * Document defaults are handled correctly: provided external defaults replace built-in defaults, while built-in defaults remain when external styles omit them.
  * When external styles introduce unknown identifiers, only the targeted built-in entries are overridden; other built-in styles remain.
* **Tests**
  * Expanded coverage for external styles and document defaults merging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->