### PR TITLE
fix(table): emit numeric pct widths in fiftieths of a percent

### DIFF
--- a/src/file/table/table-properties/table-cell-margin.spec.ts
+++ b/src/file/table/table-properties/table-cell-margin.spec.ts
@@ -135,7 +135,7 @@ describe("TableCellMargin", () => {
 
             const tree = new Formatter().format(cellMargin!);
             expect(tree).to.deep.equal({
-                "w:tcMar": [{ "w:left": { _attr: { "w:type": "pct", "w:w": "5%" } } }],
+                "w:tcMar": [{ "w:left": { _attr: { "w:type": "pct", "w:w": 250 } } }],
             });
         });
     });

--- a/src/file/table/table-width.spec.ts
+++ b/src/file/table/table-width.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { Formatter } from "@export/formatter";
+
+import { WidthType, createTableWidthElement } from "./table-width";
+
+describe("createTableWidthElement", () => {
+    it("writes a numeric pct width in fiftieths of a percent, matching Word (#1457)", () => {
+        // A "50%" string is misread by Google Docs / Apple Pages and collapses
+        // the table; Word writes 50% as the integer 2500.
+        const tree = new Formatter().format(createTableWidthElement("w:tblW", { size: 50, type: WidthType.PERCENTAGE }));
+
+        expect(tree).to.deep.equal({ "w:tblW": { _attr: { "w:type": "pct", "w:w": 2500 } } });
+    });
+
+    it("rounds fractional percentages to the nearest fiftieth", () => {
+        const tree = new Formatter().format(createTableWidthElement("w:tblW", { size: 33.3, type: WidthType.PERCENTAGE }));
+
+        expect(tree).to.deep.equal({ "w:tblW": { _attr: { "w:type": "pct", "w:w": 1665 } } });
+    });
+
+    it("still emits the literal percent string when the caller passes a Percentage", () => {
+        const tree = new Formatter().format(createTableWidthElement("w:tblW", { size: "50%", type: WidthType.PERCENTAGE }));
+
+        expect(tree).to.deep.equal({ "w:tblW": { _attr: { "w:type": "pct", "w:w": "50%" } } });
+    });
+
+    it("leaves dxa widths untouched", () => {
+        const tree = new Formatter().format(createTableWidthElement("w:tblW", { size: 5000, type: WidthType.DXA }));
+
+        expect(tree).to.deep.equal({ "w:tblW": { _attr: { "w:type": "dxa", "w:w": 5000 } } });
+    });
+});

--- a/src/file/table/table-width.ts
+++ b/src/file/table/table-width.ts
@@ -70,7 +70,14 @@ export type ITableWidthProperties = {
 export const createTableWidthElement = (name: string, { type = WidthType.AUTO, size }: ITableWidthProperties): XmlComponent => {
     let tableWidthValue = size;
     if (type === WidthType.PERCENTAGE && typeof size === "number") {
-        tableWidthValue = `${size}%`;
+        // For pct widths, Word writes the value in fiftieths of a percent
+        // (100% = 5000), not a "50%" string. Both forms are permitted by
+        // ST_MeasurementOrPercent, but stricter consumers — Google Docs and
+        // Apple Pages/QuickLook/Mail — misread the string form and collapse the
+        // table columns. Emit the integer to match Word's output. Callers who
+        // want the literal percent string can still pass a Percentage (e.g.
+        // "50%"). See #1457.
+        tableWidthValue = Math.round(size * 50);
     }
 
     return new BuilderElement<ITableWidthProperties>({

--- a/src/file/table/table.spec.ts
+++ b/src/file/table/table.spec.ts
@@ -281,7 +281,7 @@ describe("Table", () => {
                         "w:tblW": {
                             _attr: {
                                 "w:type": "pct",
-                                "w:w": "100%",
+                                "w:w": 5000,
                             },
                         },
                     },


### PR DESCRIPTION
## What

`createTableWidthElement` serialises a numeric `WidthType.PERCENTAGE` size as a percent **string** (`w:w="50%"`). This changes it to emit the value in **fiftieths of a percent** (`50% → 2500`), which is the form Word itself writes.

Fixes #1457 (also the root cause behind #349, #216, #3015).

## Why

For `w:tblW` / `w:tcW`, `@w:w` is `ST_MeasurementOrPercent`, whose union permits *both* an `ST_Percentage` string (`"50%"`) and an `ST_UnqualifiedPercentage` integer in fiftieths. So the current `"50%"` output is schema-valid — this is an **interoperability** issue, not a spec violation:

- **Word** writes `pct` widths as the fiftieths integer.
- **Stricter consumers** — Google Docs' `.docx` importer and Apple's shared OOXML parser (Pages, QuickLook, Mail preview, iCloud) — misread the `"50%"` string, fall back to `tblGrid`, and collapse every column to ~1 character wide (text stacked vertically). This is the long-standing "tables broken in Google Docs" report.

Emitting the integer matches Word and renders correctly everywhere, with no visual change in Word/LibreOffice.

## Compatibility

- The rendered percentage is unchanged (`{ size: 50, type: PERCENTAGE }` still means 50%).
- Only the numeric branch changes. Callers who deliberately want the literal string can still pass a `Percentage` (e.g. `{ size: "50%", type: PERCENTAGE }`) — that path is untouched.
- Note: this does change the emitted XML bytes for existing numeric-percentage callers (`"100%"` → `5000`). Two existing specs asserted the old string output and are updated. I recognise `%` was introduced deliberately in #282; happy to gate this behind an option instead if you'd prefer to preserve the exact previous bytes by default.

## Tests

- New `src/file/table/table-width.spec.ts` covering: numeric pct → fiftieths, fractional rounding, the `Percentage`-string path still emitting the string, and `dxa` untouched.
- Updated the two specs that asserted the old string (`table.spec.ts`, `table-cell-margin.spec.ts`).
- Full suite green: **1023 passed / 197 files**. Lint clean on changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table and cell percentage-width formatting for better compatibility with Word and other document editors.
  * Numeric percentage widths now use the correct Word-compatible representation, including proper rounding.
  * Preserved explicitly provided percentage strings and DXA width values.
  * Updated coverage to verify common and edge-case table width scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->