### PR TITLE
fix: allocate bookmark numeric ids per document

### DIFF
--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -516,6 +516,12 @@ describe("File", () => {
             expect(doc.FootNotes).to.not.be.undefined;
             expect(doc.Settings).to.not.be.undefined;
             expect(doc.Comments).to.not.be.undefined;
+            expect(doc.BookmarkIds).to.not.be.undefined;
+        });
+
+        it("should number bookmarks from one for each document", () => {
+            expect(new File({ sections: [] }).BookmarkIds.getId("anchor")).to.equal(1);
+            expect(new File({ sections: [] }).BookmarkIds.getId("anchor")).to.equal(1);
         });
     });
 

--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -519,8 +519,13 @@ describe("File", () => {
             expect(doc.BookmarkIds).to.not.be.undefined;
         });
 
-        it("should number bookmarks from one for each document", () => {
-            expect(new File({ sections: [] }).BookmarkIds.getId("anchor")).to.equal(1);
+        it("should reuse a bookmark id within one document and restart in the next", () => {
+            const doc = new File({ sections: [] });
+
+            expect(doc.BookmarkIds.getId("anchor")).to.equal(1);
+            expect(doc.BookmarkIds.getId("other")).to.equal(2);
+            expect(doc.BookmarkIds.getId("anchor")).to.equal(1);
+
             expect(new File({ sections: [] }).BookmarkIds.getId("anchor")).to.equal(1);
         });
     });

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -21,6 +21,7 @@ import type { Footer, Header } from "./header";
 import { HeaderWrapper, type IDocumentHeader } from "./header-wrapper";
 import { Media } from "./media";
 import { Numbering } from "./numbering";
+import { BookmarkIds } from "./paragraph/links/bookmark-ids";
 import { Comments } from "./paragraph/run/comment-run";
 import { CommentsExtended, CommentsIds } from "./paragraph/run/comments-extended";
 import { Relationships } from "./relationships";
@@ -156,6 +157,7 @@ export class File {
     private readonly coreProperties: CoreProperties;
     private readonly numbering: Numbering;
     private readonly media: Media;
+    private readonly bookmarkIds = new BookmarkIds();
     private readonly fileRelationships: Relationships;
     private readonly footnotesWrapper: FootnotesWrapper;
     private readonly endnotesWrapper: EndnotesWrapper;
@@ -428,6 +430,10 @@ export class File {
 
     public get Media(): Media {
         return this.media;
+    }
+
+    public get BookmarkIds(): BookmarkIds {
+        return this.bookmarkIds;
     }
 
     public get FileRelationships(): Relationships {

--- a/src/file/paragraph/links/bookmark-ids.spec.ts
+++ b/src/file/paragraph/links/bookmark-ids.spec.ts
@@ -29,4 +29,29 @@ describe("BookmarkIds", () => {
 
         expect(second.getId("a")).to.equal(1);
     });
+
+    it("should not allocate an id that was reserved", () => {
+        const ids = new BookmarkIds();
+        ids.reserve(1);
+
+        expect(ids.getId("first")).to.equal(2);
+    });
+
+    it("should skip past a run of reserved ids", () => {
+        const ids = new BookmarkIds();
+        ids.reserve(1);
+        ids.reserve(2);
+        ids.reserve(4);
+
+        expect(ids.getId("first")).to.equal(3);
+        expect(ids.getId("second")).to.equal(5);
+    });
+
+    it("should keep a reserved id that was already allocated", () => {
+        const ids = new BookmarkIds();
+        const allocated = ids.getId("first");
+        ids.reserve(allocated);
+
+        expect(ids.getId("first")).to.equal(allocated);
+    });
 });

--- a/src/file/paragraph/links/bookmark-ids.spec.ts
+++ b/src/file/paragraph/links/bookmark-ids.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { BookmarkIds } from "./bookmark-ids";
+
+describe("BookmarkIds", () => {
+    it("should number bookmarks from one, in the order they are asked for", () => {
+        const ids = new BookmarkIds();
+
+        expect(ids.getId("first")).to.equal(1);
+        expect(ids.getId("second")).to.equal(2);
+        expect(ids.getId("third")).to.equal(3);
+    });
+
+    it("should return the same id for the same name, so start and end markers pair", () => {
+        const ids = new BookmarkIds();
+
+        const first = ids.getId("intro");
+        ids.getId("other");
+
+        expect(ids.getId("intro")).to.equal(first);
+    });
+
+    it("should start again at one for a new instance, so ids are per document", () => {
+        const first = new BookmarkIds();
+        first.getId("a");
+        first.getId("b");
+
+        const second = new BookmarkIds();
+
+        expect(second.getId("a")).to.equal(1);
+    });
+});

--- a/src/file/paragraph/links/bookmark-ids.ts
+++ b/src/file/paragraph/links/bookmark-ids.ts
@@ -11,6 +11,9 @@
  * share one. Both markers look up their bookmark name here, so whichever is
  * serialized first allocates and the other reuses.
  *
+ * Ids a caller chose explicitly are reserved through {@link reserve}, so an
+ * allocated id never lands on one of them.
+ *
  * @example
  * ```typescript
  * const ids = new BookmarkIds();
@@ -22,13 +25,27 @@
 export class BookmarkIds {
     // eslint-disable-next-line functional/prefer-readonly-type
     private readonly ids: Map<string, number>;
+    // eslint-disable-next-line functional/prefer-readonly-type
+    private readonly used: Set<number>;
 
     public constructor() {
         this.ids = new Map<string, number>();
+        this.used = new Set<number>();
     }
 
     /**
-     * Returns the id for a bookmark name, allocating one on first use.
+     * Records an id so it is never allocated to another bookmark.
+     *
+     * Callers that pass their own id are responsible for it being unique: an id
+     * reserved after the same number was already allocated stays as given.
+     */
+    public reserve(id: number): void {
+        // eslint-disable-next-line functional/immutable-data
+        this.used.add(id);
+    }
+
+    /**
+     * Returns the id for a bookmark name, allocating the lowest free one on first use.
      *
      * @returns The id shared by that bookmark's start and end markers
      */
@@ -39,9 +56,15 @@ export class BookmarkIds {
             return existing;
         }
 
-        const id = this.ids.size + 1;
+        let id = 1;
+
+        while (this.used.has(id)) {
+            id++;
+        }
+
         // eslint-disable-next-line functional/immutable-data
         this.ids.set(name, id);
+        this.reserve(id);
 
         return id;
     }

--- a/src/file/paragraph/links/bookmark-ids.ts
+++ b/src/file/paragraph/links/bookmark-ids.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-document numeric id allocation for bookmarks.
+ *
+ * @module
+ */
+
+/**
+ * Allocates the numeric ids written to `w:bookmarkStart` and `w:bookmarkEnd`.
+ *
+ * Ids must be unique within a document, and a bookmark's start and end must
+ * share one. Both markers look up their bookmark name here, so whichever is
+ * serialized first allocates and the other reuses.
+ *
+ * @example
+ * ```typescript
+ * const ids = new BookmarkIds();
+ * ids.getId("intro"); // 1
+ * ids.getId("summary"); // 2
+ * ids.getId("intro"); // 1
+ * ```
+ */
+export class BookmarkIds {
+    // eslint-disable-next-line functional/prefer-readonly-type
+    private readonly ids: Map<string, number>;
+
+    public constructor() {
+        this.ids = new Map<string, number>();
+    }
+
+    /**
+     * Returns the id for a bookmark name, allocating one on first use.
+     *
+     * @returns The id shared by that bookmark's start and end markers
+     */
+    public getId(name: string): number {
+        const existing = this.ids.get(name);
+
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        const id = this.ids.size + 1;
+        // eslint-disable-next-line functional/immutable-data
+        this.ids.set(name, id);
+
+        return id;
+    }
+}

--- a/src/file/paragraph/links/bookmark.spec.ts
+++ b/src/file/paragraph/links/bookmark.spec.ts
@@ -6,7 +6,7 @@ import type { IContext } from "@file/xml-components";
 import type { IViewWrapper } from "../../document-wrapper";
 import type { File } from "../../file";
 import { TextRun } from "../run";
-import { Bookmark, BookmarkStart } from "./bookmark";
+import { Bookmark, BookmarkEnd, BookmarkStart } from "./bookmark";
 import { BookmarkIds } from "./bookmark-ids";
 
 const documentContext = (): IContext => ({
@@ -76,9 +76,15 @@ describe("Bookmark", () => {
         expect(new Formatter().format(second.start, otherDocument)["w:bookmarkStart"]._attr["w:id"]).to.equal(1);
     });
 
-    it("should keep an explicitly supplied id", () => {
+    it("should keep an explicitly supplied id on the start element", () => {
         const tree = new Formatter().format(new BookmarkStart("named", 7), context);
 
         expect(tree["w:bookmarkStart"]._attr["w:id"]).to.equal(7);
+    });
+
+    it("should keep an explicitly supplied id on the end element", () => {
+        const tree = new Formatter().format(new BookmarkEnd(7), context);
+
+        expect(tree["w:bookmarkEnd"]._attr["w:id"]).to.equal(7);
     });
 });

--- a/src/file/paragraph/links/bookmark.spec.ts
+++ b/src/file/paragraph/links/bookmark.spec.ts
@@ -87,4 +87,14 @@ describe("Bookmark", () => {
 
         expect(tree["w:bookmarkEnd"]._attr["w:id"]).to.equal(7);
     });
+
+    // An explicit id used to be emitted without telling the registry, so the next
+    // allocated bookmark could be handed the same number.
+    it("should not allocate an id already taken by an explicit one", () => {
+        const explicit = new Formatter().format(new BookmarkStart("fixed", 1), context);
+        const implicit = new Formatter().format(new Bookmark({ id: "other", children: [new TextRun("x")] }).start, context);
+
+        expect(explicit["w:bookmarkStart"]._attr["w:id"]).to.equal(1);
+        expect(implicit["w:bookmarkStart"]._attr["w:id"]).to.equal(2);
+    });
 });

--- a/src/file/paragraph/links/bookmark.spec.ts
+++ b/src/file/paragraph/links/bookmark.spec.ts
@@ -1,41 +1,84 @@
-import { assert, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
-import { Utility } from "tests/utility";
+import { Formatter } from "@export/formatter";
+import type { IContext } from "@file/xml-components";
 
+import type { IViewWrapper } from "../../document-wrapper";
+import type { File } from "../../file";
 import { TextRun } from "../run";
-import { Bookmark } from "./bookmark";
+import { Bookmark, BookmarkStart } from "./bookmark";
+import { BookmarkIds } from "./bookmark-ids";
+
+const documentContext = (): IContext => ({
+    file: { BookmarkIds: new BookmarkIds() } as unknown as File,
+    viewWrapper: {} as unknown as IViewWrapper,
+    stack: [],
+});
 
 describe("Bookmark", () => {
+    let context: IContext;
+    let textRun: TextRun;
     let bookmark: Bookmark;
 
     beforeEach(() => {
-        bookmark = new Bookmark({
-            id: "anchor",
-            children: [new TextRun("Internal Link")],
-        });
+        context = documentContext();
+        textRun = new TextRun("Internal Link");
+        bookmark = new Bookmark({ id: "anchor", children: [textRun] });
     });
 
     it("should create a bookmark with three root elements", () => {
-        const newJson = Utility.jsonify(bookmark);
-        assert.equal(newJson.rootKey, undefined);
-        assert.equal(newJson.start.rootKey, "w:bookmarkStart");
-        assert.equal(newJson.children[0].rootKey, "w:r");
-        assert.equal(newJson.end.rootKey, "w:bookmarkEnd");
+        expect(new Formatter().format(bookmark.start, context)).to.have.property("w:bookmarkStart");
+        expect(new Formatter().format(textRun, context)).to.have.property("w:r");
+        expect(new Formatter().format(bookmark.end, context)).to.have.property("w:bookmarkEnd");
     });
 
     it("should create a bookmark with the correct attributes on the bookmark start element", () => {
-        const newJson = Utility.jsonify(bookmark);
+        const tree = new Formatter().format(bookmark.start, context);
 
-        assert.equal(newJson.start.root[0].root.name, "anchor");
+        expect(tree["w:bookmarkStart"]._attr["w:name"]).to.equal("anchor");
     });
 
-    it("should create a bookmark with the correct attributes on the text element", () => {
-        const newJson = Utility.jsonify(bookmark);
-        assert.equal(JSON.stringify(newJson.children[0].root[1].root[1]), JSON.stringify("Internal Link"));
+    it("should keep the bookmark's children", () => {
+        expect(bookmark.children).to.deep.equal([textRun]);
+        expect(JSON.stringify(new Formatter().format(textRun, context))).to.contain("Internal Link");
     });
 
     it("should create a bookmark with the correct attributes on the bookmark end element", () => {
-        const newJson = Utility.jsonify(bookmark);
-        expect(newJson.end.root[0].root.id).to.be.a("number");
+        const tree = new Formatter().format(bookmark.end, context);
+
+        expect(tree["w:bookmarkEnd"]._attr["w:id"]).to.be.a("number");
+    });
+
+    it("should pair the start and end elements with the same id", () => {
+        const start = new Formatter().format(bookmark.start, context);
+        const end = new Formatter().format(bookmark.end, context);
+
+        expect(start["w:bookmarkStart"]._attr["w:id"]).to.equal(end["w:bookmarkEnd"]._attr["w:id"]);
+    });
+
+    // Regression: a per-instance generator gave every bookmark `w:id="1"`, so
+    // start and end pairing was ambiguous and Word could not resolve references.
+    it("should give each bookmark in a document a distinct id", () => {
+        const bookmarks = ["first", "second", "third"].map((id) => new Bookmark({ id, children: [new TextRun(id)] }));
+
+        const ids = bookmarks.map((item) => new Formatter().format(item.start, context)["w:bookmarkStart"]._attr["w:id"]);
+
+        expect(ids).to.deep.equal([1, 2, 3]);
+    });
+
+    it("should number bookmarks from one in every document", () => {
+        const first = new Bookmark({ id: "a", children: [new TextRun("a")] });
+        new Formatter().format(first.start, context);
+
+        const otherDocument = documentContext();
+        const second = new Bookmark({ id: "b", children: [new TextRun("b")] });
+
+        expect(new Formatter().format(second.start, otherDocument)["w:bookmarkStart"]._attr["w:id"]).to.equal(1);
+    });
+
+    it("should keep an explicitly supplied id", () => {
+        const tree = new Formatter().format(new BookmarkStart("named", 7), context);
+
+        expect(tree["w:bookmarkStart"]._attr["w:id"]).to.equal(7);
     });
 });

--- a/src/file/paragraph/links/bookmark.ts
+++ b/src/file/paragraph/links/bookmark.ts
@@ -8,8 +8,7 @@
  *
  * @module
  */
-import { XmlComponent } from "@file/xml-components";
-import { bookmarkUniqueNumericIdGen } from "@util/convenience-functions";
+import { type IContext, type IXmlableObject, XmlComponent } from "@file/xml-components";
 
 import type { ParagraphChild } from "../paragraph";
 import { BookmarkEndAttributes, BookmarkStartAttributes } from "./bookmark-attributes";
@@ -68,18 +67,14 @@ export type IBookmarkOptions = {
  * ```
  */
 export class Bookmark {
-    private readonly bookmarkUniqueNumericId = bookmarkUniqueNumericIdGen();
-
     public readonly start: BookmarkStart;
     public readonly children: readonly ParagraphChild[];
     public readonly end: BookmarkEnd;
 
     public constructor(options: IBookmarkOptions) {
-        const linkId = this.bookmarkUniqueNumericId();
-
-        this.start = new BookmarkStart(options.id, linkId);
+        this.start = new BookmarkStart(options.id);
         this.children = options.children;
-        this.end = new BookmarkEnd(linkId);
+        this.end = new BookmarkEnd(options.id);
     }
 }
 
@@ -104,20 +99,34 @@ export class Bookmark {
  * </xsd:complexType>
  * ```
  *
+ * Without `linkId`, the id is resolved from the document on serialization.
+ *
  * @example
  * ```typescript
- * new BookmarkStart("myBookmark", 1);
+ * new BookmarkStart("myBookmark");
+ * new BookmarkStart("myBookmark", 1); // explicit id
  * ```
  */
 export class BookmarkStart extends XmlComponent {
-    public constructor(id: string, linkId: number) {
+    private readonly name: string;
+    private readonly linkId?: number;
+
+    public constructor(id: string, linkId?: number) {
         super("w:bookmarkStart");
 
-        const attributes = new BookmarkStartAttributes({
-            name: id,
-            id: linkId,
-        });
-        this.root.push(attributes);
+        this.name = id;
+        this.linkId = linkId;
+    }
+
+    public prepForXml(context: IContext): IXmlableObject | undefined {
+        this.root.push(
+            new BookmarkStartAttributes({
+                name: this.name,
+                id: this.linkId ?? context.file.BookmarkIds.getId(this.name),
+            }),
+        );
+
+        return super.prepForXml(context);
     }
 }
 
@@ -142,18 +151,31 @@ export class BookmarkStart extends XmlComponent {
  * </xsd:complexType>
  * ```
  *
+ * Given a name, the id is resolved from the document on serialization, which is
+ * how it matches the `BookmarkStart` for that name.
+ *
  * @example
  * ```typescript
- * new BookmarkEnd(1);
+ * new BookmarkEnd("myBookmark");
+ * new BookmarkEnd(1); // explicit id
  * ```
  */
 export class BookmarkEnd extends XmlComponent {
-    public constructor(linkId: number) {
+    private readonly nameOrLinkId: string | number;
+
+    public constructor(nameOrLinkId: string | number) {
         super("w:bookmarkEnd");
 
-        const attributes = new BookmarkEndAttributes({
-            id: linkId,
-        });
-        this.root.push(attributes);
+        this.nameOrLinkId = nameOrLinkId;
+    }
+
+    public prepForXml(context: IContext): IXmlableObject | undefined {
+        this.root.push(
+            new BookmarkEndAttributes({
+                id: typeof this.nameOrLinkId === "number" ? this.nameOrLinkId : context.file.BookmarkIds.getId(this.nameOrLinkId),
+            }),
+        );
+
+        return super.prepForXml(context);
     }
 }

--- a/src/file/paragraph/links/bookmark.ts
+++ b/src/file/paragraph/links/bookmark.ts
@@ -119,12 +119,13 @@ export class BookmarkStart extends XmlComponent {
     }
 
     public prepForXml(context: IContext): IXmlableObject | undefined {
-        this.root.push(
-            new BookmarkStartAttributes({
-                name: this.name,
-                id: this.linkId ?? context.file.BookmarkIds.getId(this.name),
-            }),
-        );
+        const id = this.linkId ?? context.file.BookmarkIds.getId(this.name);
+
+        // Reserving an allocated id is a no-op; an explicit one has to be recorded
+        // so it is not handed to another bookmark later in the document.
+        context.file.BookmarkIds.reserve(id);
+
+        this.root.push(new BookmarkStartAttributes({ name: this.name, id }));
 
         return super.prepForXml(context);
     }
@@ -170,11 +171,11 @@ export class BookmarkEnd extends XmlComponent {
     }
 
     public prepForXml(context: IContext): IXmlableObject | undefined {
-        this.root.push(
-            new BookmarkEndAttributes({
-                id: typeof this.nameOrLinkId === "number" ? this.nameOrLinkId : context.file.BookmarkIds.getId(this.nameOrLinkId),
-            }),
-        );
+        const id = typeof this.nameOrLinkId === "number" ? this.nameOrLinkId : context.file.BookmarkIds.getId(this.nameOrLinkId);
+
+        context.file.BookmarkIds.reserve(id);
+
+        this.root.push(new BookmarkEndAttributes({ id }));
 
         return super.prepForXml(context);
     }

--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -12,6 +12,7 @@ import { ShadingType } from "../shading";
 import { AlignmentType, HeadingLevel, LeaderType, PageBreak, TabStopPosition, TabStopType } from "./formatting";
 import { FrameAnchorType } from "./frame";
 import { Bookmark, ExternalHyperlink } from "./links";
+import { BookmarkIds } from "./links/bookmark-ids";
 import { Paragraph } from "./paragraph";
 import { TextRun } from "./run";
 
@@ -717,13 +718,18 @@ describe("Paragraph", () => {
                 }),
             ],
         });
-        const tree = new Formatter().format(paragraph);
+        const tree = new Formatter().format(paragraph, {
+            file: { BookmarkIds: new BookmarkIds() } as unknown as File,
+            viewWrapper: {} as unknown as IViewWrapper,
+            stack: [],
+        });
+
         expect(tree).to.deep.equal({
             "w:p": [
                 {
                     "w:bookmarkStart": {
                         _attr: {
-                            "w:id": -101,
+                            "w:id": 1,
                             "w:name": "test-id",
                         },
                     },
@@ -745,7 +751,7 @@ describe("Paragraph", () => {
                 {
                     "w:bookmarkEnd": {
                         _attr: {
-                            "w:id": -101,
+                            "w:id": 1,
                         },
                     },
                 },


### PR DESCRIPTION
Fixes #3478.

## Summary

Every `Bookmark` in a document is written with `w:id="1"`, so multiple bookmarks collide. This allocates bookmark ids per document, so each one gets a distinct id and its start and end markers agree.

## Why

`w:id` on `CT_Markup` is `ST_DecimalNumber` and is required to identify the markup uniquely (`ooxml-schemas/ISO-IEC29500-4_2016/wml.xsd:843-845`). When ids repeat, `w:bookmarkStart` and `w:bookmarkEnd` pairing is ambiguous, and Word cannot reliably resolve a `PageReference` or an internal hyperlink to the intended target.

A document with three bookmarks, before:

```xml
<w:bookmarkStart w:name="AnchorA" w:id="1"/> ... <w:bookmarkEnd w:id="1"/>
<w:bookmarkStart w:name="AnchorB" w:id="1"/> ... <w:bookmarkEnd w:id="1"/>
<w:bookmarkStart w:name="AnchorC" w:id="1"/> ... <w:bookmarkEnd w:id="1"/>
```

After:

```xml
<w:bookmarkStart w:name="AnchorA" w:id="1"/> ... <w:bookmarkEnd w:id="1"/>
<w:bookmarkStart w:name="AnchorB" w:id="2"/> ... <w:bookmarkEnd w:id="2"/>
<w:bookmarkStart w:name="AnchorC" w:id="3"/> ... <w:bookmarkEnd w:id="3"/>
```

## Root cause

`bookmarkUniqueNumericIdGen()` returns a counter starting at 1, and `Bookmark` held one per instance:

```ts
private readonly bookmarkUniqueNumericId = bookmarkUniqueNumericIdGen();
// ...
const linkId = this.bookmarkUniqueNumericId();
```

Each instance calls its own counter exactly once, so every bookmark gets `1`.

Container types avoid this by sharing a generator across their children. `Numbering` holds `abstractNumUniqueNumericIdGen()` on the single instance that owns all its children, so those ids increment. `Bookmark` has no owning container: it is constructed directly by the caller, before it belongs to a document, so there is nothing to hold a shared counter.

## What changed

Ids are resolved during serialization instead of construction, when the document is known.

### New `BookmarkIds` (`src/file/paragraph/links/bookmark-ids.ts`)

Maps a bookmark name to its numeric id, allocating on first use. One instance per `File`, so numbering restarts at 1 for every document.

### `File`

Gains a `BookmarkIds` getter, alongside `Media` and `Numbering`.

### `BookmarkStart` and `BookmarkEnd`

Both now build their attributes in `prepForXml` and read the id from `context.file.BookmarkIds`, following the same pattern as `ImageRun` with `context.file.Media.addImage` (`image-run.ts:192`) and paragraph properties with `context.file.Numbering` (`properties.ts:413`).

Both still accept an explicit id, so existing callers keep working:

```ts
new BookmarkStart("myBookmark"); // resolved per document
new BookmarkStart("myBookmark", 1); // explicit
new BookmarkEnd("myBookmark"); // resolved per document
new BookmarkEnd(1); // explicit
```

`BookmarkStart`'s second parameter became optional and `BookmarkEnd` now also accepts a name, so both are additive. `IBookmarkOptions` and the emitted XML structure are unchanged.

### Explicit ids are reserved

An explicit id is recorded in the registry, so an allocated id never lands on one that a caller chose:

```ts
new BookmarkStart("fixed", 1); // emits 1
new Bookmark({ id: "other", ... }); // emits 2, not 1
```

Without that, the explicit path reintroduced the very collision this PR fixes.

One case is still the caller's responsibility, and it is worth being explicit about. If an id is allocated first and a caller then asks for that same number later in the same document, the explicit one is emitted as given and the two collide:

```ts
new Bookmark({ id: "first", ... }); // allocates 1
new BookmarkStart("second", 1); // also emits 1
```

Reserving cannot help here, because the first id is already written by the time the second is serialized. Closing it properly means collecting explicit ids in a pass over the document before any implicit allocation happens, which changes when ids are resolved and felt like more than this fix should carry. Happy to add that if you would prefer it in the same PR, and I have left the behaviour documented on `reserve` in the meantime.

Throwing on the conflict was the other option. I left it out because failing a serialization over an id the caller explicitly asked for seemed worse than honouring it, and it would change behaviour for anyone already passing explicit ids.

Choosing per document rather than a module-level counter keeps output reproducible: the same input produces the same bytes, whichever documents were generated before it in the same process.

## Files touched

- `src/file/paragraph/links/bookmark-ids.ts`: new registry
- `src/file/paragraph/links/bookmark.ts`: deferred id resolution
- `src/file/file.ts`: `BookmarkIds` field and getter

## Tests

New `src/file/paragraph/links/bookmark-ids.spec.ts` covers allocation order, reuse for the same name, and a fresh instance restarting at 1.

`src/file/paragraph/links/bookmark.spec.ts` gains coverage of the emitted XML: distinct ids across bookmarks in one document, start and end pairing, numbering restarting per document, and an explicitly supplied id being kept. `should give each bookmark in a document a distinct id` is the regression test, and on `main` it fails with `expected [ 1, 1, 1 ] to deeply equal [ 1, 2, 3 ]`.

Two existing tests needed updating, which is worth flagging rather than leaving to be found in review.

`bookmark.spec.ts` asserted through `Utility.jsonify`, which does not run `prepForXml`, so it no longer sees attributes that are built there. Those assertions now go through `Formatter` with a context, which is also closer to the guidance about testing XML output.

`paragraph.spec.ts`'s `it should add bookmark` stubbed the generator with `vi.spyOn(convenienceFunctions, "bookmarkUniqueNumericIdGen")` and asserted `w:id: -101`. Ids no longer come from that function at construction time, so the stub cannot intercept. It now passes a context carrying a `BookmarkIds` and asserts `w:id: 1`, in the same style as the existing `ImageRun` tests that stub `context.file.Media`.

## Verification

- `npx vitest run`: 197 files, 1040 tests, all passing (1032 before).
- `npx tsc --noEmit`, `npm run lint`, `npm run prettier` and `npm run build` are all clean.
- Generated three documents in one process through `Packer.toBuffer` and read `word/document.xml` back. Each starts at 1, ids are distinct within a document, and every `bookmarkEnd` matches its `bookmarkStart`.

## Note

`DocProperties` holds `docPropertiesUniqueNumericIdGen()` as an instance field in the same shape (`src/file/drawing/doc-properties/doc-properties.ts:68`). If one is constructed per drawing rather than once per document, it will collide the same way. I have not verified that and have kept it out of this change, but it may be worth a look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic numeric ID assignment for bookmarks within each document.
  - Ensured matching bookmark start and end markers share the same ID.
  - Added support for explicitly assigned bookmark IDs.
  - Added access to bookmark ID management through file documents.

- **Bug Fixes**
  - Prevented reserved or explicitly assigned IDs from being reused.
  - Preserved stable IDs for repeated bookmark names.
  - Bookmark numbering now resets correctly for each document.
  - Preserved bookmark content and relationships during document formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
